### PR TITLE
Prevent type error if property is read only

### DIFF
--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -19,9 +19,12 @@ function makeExportsHot(m) {
   for (var key in m.exports) {
     if (freshExports.hasOwnProperty(key) &&
         isReactClassish(freshExports[key])) {
-
-      m.exports[key] = m.makeHot(freshExports[key], '__MODULE_EXPORTS_' + key);
-      foundReactClasses = true;
+      if (Object.getOwnPropertyDescriptor(m.exports,key).writable) {
+      	m.exports[key] = m.makeHot(freshExports[key], '__MODULE_EXPORTS_' + key);
+      	foundReactClasses = true;
+      } else {
+      	console.warn("Can't make class " + key + " hot reloadable due to being read-only");
+      }
     }
   }
 


### PR DESCRIPTION
Some React class exports are read only (react-intl as an example)
If they are then don't redefine them and warn instead