### PR TITLE
Fix for modules with null [[Prototype]] chain

### DIFF
--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -17,7 +17,7 @@ function makeExportsHot(m) {
   }
 
   for (var key in m.exports) {
-    if (freshExports.hasOwnProperty(key) &&
+    if (Object.prototype.hasOwnProperty.call(freshExports, key) &&
         isReactClassish(freshExports[key])) {
       if (Object.getOwnPropertyDescriptor(m.exports, key).writable) {
         m.exports[key] = m.makeHot(freshExports[key], '__MODULE_EXPORTS_' + key);


### PR DESCRIPTION
This is a PR for https://github.com/gaearon/react-hot-loader/issues/81

A module created in the following ways:
```
module.exports = Object.create(null)
// or
module.exports = { __proto__: null }
```
won't have `hasOwnProperty()` available on it.

So it’s safer to use `Object.prototype.hasOwnProperty.call(myObj, prop)` instead of `myObj.hasOwnProperty(prop)`.