### PR TITLE
Add support for React 0.13-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "source-map": "0.1.40"
   },
   "peerDependencies": {
-    "react": ">=0.11.0 || >=0.13.0-beta.1"
+    "react": ">=0.11.0 || >=0.13.0-beta.1 || >=0.13.0-rc1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Installing this fails with 0.13.0-rc1. I guess it doesn't look greater than `-beta.1`. Feel free to change this as needed. Maybe just `>=0.13.0` would work.