### PR TITLE
use escaped unicode for property values when using content

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -165,7 +165,7 @@ a:hover:after {
   display: inline-block;
 }
 .nav-list-item ~ .nav-list-item:before {
-  content: '・';
+  content: '\00B7';
   margin: 0 .125rem;
   opacity: .25;
 }


### PR DESCRIPTION
*snort*

renders most of the time, but i've had this happen to me when checking back:

![screen shot 2015-03-17 at 3 13 52 pm](https://cloud.githubusercontent.com/assets/182661/6695520/4b25434a-ccb8-11e4-85df-968439f69ddf.png)
