### PR TITLE
Prevents makeHot() twice on a React 0.12 component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 * [coffee-react-quickstart](https://github.com/KyleAMathews/coffee-react-quickstart) (react-router, CoffeeScript, Gulp)
 * [boilerplate-webpack-react](https://github.com/tcoopman/boilerplate-webpack-react) (react-router, isomorphic)
 * [este](http://github.com/steida/este) (react-router, isomorphic, Flux, Babel)
+* [react-isomorphic-starterkit](https://github.com/RickWong/react-isomorphic-starterkit) (react-router, react-async, isomorphic)
 
 Don't be shy, add your own.
 

--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -7,17 +7,19 @@ function makeExportsHot(m, React) {
   if (isReactElementish(m.exports)) {
     return false;
   }
-
+  
   var freshExports = m.exports,
+      exportsIsReactClass = isReactClassish(m.exports, React),
       foundReactClasses = false;
 
-  if (isReactClassish(m.exports, React)) {
+  if (exportsIsReactClass) {
     m.exports = m.makeHot(m.exports, '__MODULE_EXPORTS');
     foundReactClasses = true;
   }
 
   for (var key in m.exports) {
-    if (Object.prototype.hasOwnProperty.call(freshExports, key) &&
+    if ((!exportsIsReactClass || key !== "type") &&
+        Object.prototype.hasOwnProperty.call(freshExports, key) &&
         isReactClassish(freshExports[key], React)) {
       if (Object.getOwnPropertyDescriptor(m.exports, key).writable) {
         m.exports[key] = m.makeHot(freshExports[key], '__MODULE_EXPORTS_' + key);


### PR DESCRIPTION
Take this example:

````
var C = React.createClass(...);
module.exports = C;
````

Currently React Hot Loader will call `makeExportsHot(module.exports, React)` where not only `makeHot(C, '__MODULE_EXPORTS')` is performed, but also by property-traversal `makeHot(C.type, '__MODULE_EXPORTS_type')`. The issue with this is upon modifying and hot-loading C, the component is actually updated twice and React lifecycle methods like `render` are also executed twice.

This patch fixes that redundant behavior.


