### PR TITLE
Add yarsk to starter kits

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 * [boilerplate-webpack-react](https://github.com/tcoopman/boilerplate-webpack-react) (react-router, isomorphic)
 * [este](http://github.com/steida/este) (react-router, isomorphic, Flux, Babel)
 * [react-isomorphic-starterkit](https://github.com/RickWong/react-isomorphic-starterkit) (react-router, react-async, isomorphic)
+* [yarsk](https://github.com/bradleyboy/yarsk) (Babel, Karma + Mocha, automated publishing to GitHub pages)
 
 Don't be shy, add your own.
 


### PR DESCRIPTION
Hi - I have a simple starter kit known as **yarsk** (Yet Another React Starter Kit) that has hot-loading enabled out of the box.