### PR TITLE
Pass React to isReactElementish

### DIFF
--- a/isReactElementish.js
+++ b/isReactElementish.js
@@ -1,12 +1,12 @@
 var isReactClassish = require('./isReactClassish');
 
-function isReactElementish(obj) {
+function isReactElementish(obj, React) {
   if (!obj) {
     return false;
   }
 
   return Object.prototype.toString.call(obj.props) === '[object Object]' &&
-         isReactClassish(obj.type);
+         isReactClassish(obj.type, React);
 }
 
 module.exports = isReactElementish;

--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -4,7 +4,7 @@ var isReactClassish = require('./isReactClassish'),
     isReactElementish = require('./isReactElementish');
 
 function makeExportsHot(m, React) {
-  if (isReactElementish(m.exports)) {
+  if (isReactElementish(m.exports, React)) {
     // React elements are never valid React classes
     return false;
   }


### PR DESCRIPTION
I was tracking down a weird problem and in the course of it, got an error saying that React was undefined [here][1]. It turned out that it was because `isReactElementish` doesn't pass `React` to `isReactClassish` when it calls it [here][2].

My weird error ended up being unrelated to this and in normal operation, I never seem to get to this branch, but it seems like `React` isn't an optional argument to `isReactClassish` and therefore needs to be given to the stuff that calls it (like `isReactElementish` too) so I figured I'd open this PR (:


[1]: https://github.com/gaearon/react-hot-loader/blob/ea86b4684b7846d82fe6c11e46c93f2bc55d2b49/isReactClassish.js#L11
[2]: https://github.com/gaearon/react-hot-loader/blob/ea86b4684b7846d82fe6c11e46c93f2bc55d2b49/isReactElementish.js#L9