### PR TITLE
Remove NoErrorsPlugin

### DIFF
--- a/getstarted.md
+++ b/getstarted.md
@@ -37,7 +37,7 @@ In your <a href="https://github.com/gaearon/react-hot-boilerplate/blob/master/we
 {% highlight js %}
 entry: [
   'webpack-dev-server/client?http://0.0.0.0:3000', // WebpackDevServer host and port
-  'webpack/hot/only-dev-server',
+  'webpack/hot/only-dev-server', // Use hot/only-dev-server to prevent reload on syntax errors
   './scripts/index' // Your appʼs entry point
 ]
 {% endhighlight %}
@@ -60,12 +60,11 @@ Finally, the Hot Replacement plugin from Webpack has to be included in the `plug
 
 {% highlight js %}
 plugins: [
-  new webpack.HotModuleReplacementPlugin(),
-  new webpack.NoErrorsPlugin()
+  new webpack.HotModuleReplacementPlugin()
 ]
 {% endhighlight %}
 
-`webpack.NoErrorsPlugin` is an optional plugin that tells the reloader to not reload if there is a syntax error in your code. The error is simply printed in the console, and the component will reload when you fix the error.
+>Note: If you are using Webpack Dev Server command line interface instead of its Node API, and you specify `--hot` mode, *don't* add this plugin. It is mutually exclusive with the `--hot` option.
 
 ### Usage
 


### PR DESCRIPTION
This is something silly I've been doing and recommending for a long time. Sorry! There's no need for `NoErrorsPlugin` if you use `hot/only-dev-server`. Hot updates won't blow your app away if you make a syntax error, but at least you'll see the error in the DevTools console! And the subsequent hot updates will just work when you fix that error.