### PR TITLE
Remove React from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "react-hot-api": "^0.4.4",
     "source-map": "0.1.40"
   },
-  "peerDependencies": {
-    "react": ">=0.11.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/gaearon/react-hot-loader.git"


### PR DESCRIPTION
So I propose we just do this.

I'm not jumping on the “peerDeps are hard let's just remove all of them” train here, but I think it really makes sense for RHL because:

* I intend to support future major versions.
* I don't intend to cut support for previous React versions without incrementing RHL's major version.
* If it breaks, it's not “upgrading broke our website in production!!” case. It's just a devtool.
* Removing the peer dep lets people install alpha versions of React without RHL complaining.

Any objections?