### PR TITLE
Update makeExportsHot warning message

### DIFF
--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -37,7 +37,7 @@ function makeExportsHot(m, React) {
       m.exports[key] = m.makeHot(freshExports[key], '__MODULE_EXPORTS_' + key);
       foundReactClasses = true;
     } else {
-      console.warn("Can't make class " + key + " hot reloadable due to being read-only. You can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration.");
+      console.warn("Can't make class " + key + " hot reloadable due to being read-only. To fix this you can try two solutions. First, you can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration. Second, if you are using Babel, you can enable loose mode for `es6.modules` using the 'loose' option. See: http://babeljs.io/docs/advanced/loose/ and http://babeljs.io/docs/usage/options/");
     }
   }
 


### PR DESCRIPTION
Since issues can occur when renaming exports, suggest to use loose mode on Babel to prevent read-only issues.

![screen shot 2015-07-13 at 10 11 06 am](https://cloud.githubusercontent.com/assets/3857324/8653050/e4bff6b2-2947-11e5-8104-92851db508b6.png)

Related to #158.