### PR TITLE
Check if module exists before using it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (source, map) {
 
   prependText = [
     '/* REACT HOT LOADER */',
-    'if (module.hot) {',
+    'if ("object"==typeof module && module.hot) {',
       '(function () {',
         'var ReactHotAPI = require(' + JSON.stringify(require.resolve('react-hot-api')) + '),',
             'RootInstanceProvider = require(' + JSON.stringify(require.resolve('./RootInstanceProvider')) + '),',
@@ -43,7 +43,7 @@ module.exports = function (source, map) {
   appendText = [
     '/* REACT HOT LOADER */',
     '}).call(this);',
-    'if (module.hot) {',
+    'if ("object"==typeof module && module.hot) {',
       '(function () {',
         'module.hot.dispose(function (data) {',
           'data.makeHot = module.makeHot;',


### PR DESCRIPTION
I realize this is an edge case, but I ran into a situation recently. 

I needed some static, non-commonjs, JS to be put in the output directory using file-loader, and react-hot-loader kept injecting itself, and therefore, causing runtime errors.

The solution was simple. Instead of adding config to the loader to ignore stuff, I simply check for module before using it.