### PR TITLE
Add React Typescript Boilerplate.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 * [react-cordova-boilerplate](https://github.com/unimonkiez/react-cordova-boilerplate) (react with react-router, redux, hot loader and server-rendering for cordova)
 * [react-hot-boilerplate-ts](https://github.com/wmaurer/react-hot-boilerplate-ts) (hot reloadable typescript starter kit)
 * [Megatome](https://github.com/Levelmoney/generator-megatome) (Yeoman generator w/ dynamic switchable rendering on Node/browser, react-router, babel, isomophic, an easy config building environments, bring-your-own-data-model and docker)
+* [react-typescript-boilerplate](https://github.com/keokilee/react-typescript-boilerplate) (Redux with React Transform HMR, Typescript with tslint, and Babel)
 
 Don't be shy, add your own.
 


### PR DESCRIPTION
Add another react-typescript-boilerplate to examples. This actually uses React Transform HMR, so I'm not actually sure if this is the right place or not. Especially since this repo is going to be deprecated.