### PR TITLE
Test also properties of module.exports.default

### DIFF
--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -4,51 +4,60 @@ var isReactClassish = require('./isReactClassish'),
     isReactElementish = require('./isReactElementish');
 
 function makeExportsHot(m, React) {
-  if (isReactElementish(m.exports, React)) {
-    // React elements are never valid React classes
-    return false;
+  function testMembers(exports) {
+    if (isReactElementish(exports, React)) {
+        // React elements are never valid React classes
+        return false;
+    }
+
+    var freshExports = exports,
+        exportsReactClass = isReactClassish(exports, React),
+        foundReactClasses = false;
+
+    if (exportsReactClass) {
+        exports = m.makeHot(exports, '__MODULE_EXPORTS');
+        foundReactClasses = true;
+    }
+
+    for (var key in exports) {
+        if (!Object.prototype.hasOwnProperty.call(freshExports, key)) {
+        continue;
+        }
+
+        if (exportsReactClass && key === 'type') {
+        // React 0.12 also puts classes under `type` property for compat.
+        // Skip to avoid updating twice.
+        continue;
+        }
+
+        var value;
+        try {
+        value = freshExports[key];
+        } catch (err) {
+        continue;
+        }
+
+        if (!isReactClassish(value, React)) {
+        continue;
+        }
+
+        if (Object.getOwnPropertyDescriptor(exports, key).writable) {
+        exports[key] = m.makeHot(value, '__MODULE_EXPORTS_' + key);
+        foundReactClasses = true;
+        } else {
+        console.warn("Can't make class " + key + " hot reloadable due to being read-only. To fix this you can try two solutions. First, you can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration. Second, if you are using Babel, you can enable loose mode for `es6.modules` using the 'loose' option. See: http://babeljs.io/docs/advanced/loose/ and http://babeljs.io/docs/usage/options/");
+        }
+    }
+    return foundReactClasses;
   }
 
-  var freshExports = m.exports,
-      exportsReactClass = isReactClassish(m.exports, React),
-      foundReactClasses = false;
-
-  if (exportsReactClass) {
-    m.exports = m.makeHot(m.exports, '__MODULE_EXPORTS');
-    foundReactClasses = true;
+  if (testMembers(m.exports)) {
+      return true;
   }
-
-  for (var key in m.exports) {
-    if (!Object.prototype.hasOwnProperty.call(freshExports, key)) {
-      continue;
-    }
-
-    if (exportsReactClass && key === 'type') {
-      // React 0.12 also puts classes under `type` property for compat.
-      // Skip to avoid updating twice.
-      continue;
-    }
-
-    var value;
-    try {
-      value = freshExports[key];
-    } catch (err) {
-      continue;
-    }
-
-    if (!isReactClassish(value, React)) {
-      continue;
-    }
-
-    if (Object.getOwnPropertyDescriptor(m.exports, key).writable) {
-      m.exports[key] = m.makeHot(value, '__MODULE_EXPORTS_' + key);
-      foundReactClasses = true;
-    } else {
-      console.warn("Can't make class " + key + " hot reloadable due to being read-only. To fix this you can try two solutions. First, you can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration. Second, if you are using Babel, you can enable loose mode for `es6.modules` using the 'loose' option. See: http://babeljs.io/docs/advanced/loose/ and http://babeljs.io/docs/usage/options/");
-    }
+  else if (typeof m.exports.default == "object") {
+      return testMembers(m.exports.default);
   }
-
-  return foundReactClasses;
+  return false;
 }
 
 module.exports = makeExportsHot;


### PR DESCRIPTION
I know this is not frequent but it may happen that React components are exposed as properties of a default export (as it occurs, for example, when compiling F# to JS with [Fable](https://github.com/fsprojects/Fable)). This PR just adds an additional test on members of `m.exports.default` when no React classes have been found for `m.exports`.

Thanks a lot for this wonderful tool, Dan!
