### PR TITLE
added failing AppContainer test for force update when passing component as children

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,13 @@
     "babel-core": "^6.7.6",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "enzyme": "^2.2.0",
     "expect": "^1.16.0",
+    "jsdom": "^8.4.1",
     "mocha": "^2.4.5",
     "react": "^15.0.1",
+    "react-addons-test-utils": "^15.0.2",
+    "react-dom": "^15.0.2",
     "rimraf": "^2.5.2"
   }
 }

--- a/test/AppContainer/AppContainer.dev.js
+++ b/test/AppContainer/AppContainer.dev.js
@@ -1,0 +1,160 @@
+import './setup'
+import React, {Component} from 'react'
+import expect, {createSpy} from 'expect'
+import {mount} from 'enzyme'
+
+import AppContainer from '../../src/AppContainer.dev'
+
+const tag = (comp, name) => comp.__source = { fileName: name, localName: name }
+
+describe('<AppContainer />', () => {
+  describe('when passed children', () => {
+    it('renders it', () => {
+      const spy = createSpy()
+      class App extends Component {
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer><App /></AppContainer>)
+      expect(wrapper.find('App').length).toBe(1)
+      expect(wrapper.contains(<div>hey</div>)).toBe(true)
+      expect(spy.calls.length).toBe(1)
+    })
+
+    it('doesnt force update the tree when receiving the same', () => {
+      const spy = createSpy()
+      class App extends Component {
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer><App /></AppContainer>)
+      expect(spy.calls.length).toBe(1)
+      wrapper.setProps({children: <App />})
+      expect(spy.calls.length).toBe(1)
+    })
+
+    it('force updates the tree when receiving different', () => {
+      const spy = createSpy()
+
+      class App extends Component {
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer><App /></AppContainer>)
+      expect(spy.calls.length).toBe(1)
+
+      {
+        class App extends Component {
+          shouldComponentUpdate() {
+            return false
+          }
+
+          render() {
+            spy()
+            return <div>ho</div>
+          }
+        }
+        tag(App, 'App')
+        wrapper.setProps({children: <App />})
+      }
+
+      expect(spy.calls.length).toBe(2)
+      expect(wrapper.contains(<div>ho</div>)).toBe(true)
+    })
+  })
+
+  describe('when passed component prop', () => {
+    it('renders it', () => {
+      const spy = createSpy()
+      class App extends Component {
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer component={App}></AppContainer>)
+      expect(wrapper.find('App').length).toBe(1)
+      expect(wrapper.contains(<div>hey</div>)).toBe(true)
+      expect(spy.calls.length).toBe(1)
+    })
+
+    it('doesnt force update the tree when receiving the same', () => {
+      const spy = createSpy()
+      class App extends Component {
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer component={App}></AppContainer>)
+      expect(spy.calls.length).toBe(1)
+      wrapper.setProps({component: App})
+      expect(spy.calls.length).toBe(1)
+    })
+
+    it('force updates the tree when receiving different', () => {
+      const spy = createSpy()
+
+      class App extends Component {
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          spy()
+          return <div>hey</div>
+        }
+      }
+      tag(App, 'App')
+
+      const wrapper = mount(<AppContainer component={App}></AppContainer>)
+      expect(spy.calls.length).toBe(1)
+
+      {
+        class App extends Component {
+          shouldComponentUpdate() {
+            return false
+          }
+
+          render() {
+            spy()
+            return <div>ho</div>
+          }
+        }
+        tag(App, 'App')
+        wrapper.setProps({component: App})
+      }
+
+      expect(spy.calls.length).toBe(2)
+      expect(wrapper.contains(<div>ho</div>)).toBe(true)
+    })
+  })
+})

--- a/test/AppContainer/index.js
+++ b/test/AppContainer/index.js
@@ -1,0 +1,1 @@
+import './AppContainer.dev'

--- a/test/AppContainer/setup.js
+++ b/test/AppContainer/setup.js
@@ -1,0 +1,21 @@
+// the if statement is to prevent patching again when using mocha watch mode
+if (!require('react').createElement.isPatchedByReactHotLoader)
+  require('../../src/patch.dev')
+
+// copied from https://github.com/lelandrichardson/enzyme-example-mocha/blob/master/test/.setup.js
+var jsdom = require('jsdom').jsdom;
+
+var exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 import './babel';
 import './fixupReactRouter';
+import './AppContainer';


### PR DESCRIPTION
see the failing test.
it's because this line https://github.com/gaearon/react-hot-loader/blob/next/src/AppContainer.dev.js#L77 doesn't work as expected — since the component was passed as children, by the time it appears in AppContainer's lifecycle methods it has already gone through React.createElement, therefore it has already been replaced the proxy, thus (unless react-proxy malfunctions) `children.type` will always be equal to that of the previous props.

I was actually not out to find this bug. I was experimenting with writing tests for AppContainer, I guess the fact I've found this bug kind of makes the case for the tests ;)

Should I write some more tests for AppContainer, specifically does it make sense to write tests for functional components, HOCs, etc. making sure they all properly update? Or is that all covered by the tests for `react-proxy`?