### PR TITLE
More tests for AppContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",
+    "recompose": "^0.17.0",
     "rimraf": "^2.5.2"
   }
 }

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -43,15 +43,9 @@ class AppContainer extends Component {
     this.setState({
       error: null
     });
-  }
-
-  componentDidUpdate(prevProps) {
-    // Hot reload has finished.
     // Force-update the whole tree, including
     // components that refuse to update.
-    if (prevProps !== this.props) {
-      deepForceUpdate(this);
-    }
+    deepForceUpdate(this);
   }
 
   // This hook is going to become official in React 15.x.

--- a/test/AppContainer/AppContainer.dev.js
+++ b/test/AppContainer/AppContainer.dev.js
@@ -186,5 +186,104 @@ describe('<AppContainer />', () => {
         expect(wrapper.text()).toBe('new render + old state')
       })
     })
+
+    describe('with HOC-wrapped root', () => {
+      const mapProps = require('recompose').mapProps
+      it('renders it', () => {
+        const spy = createSpy()
+        class App extends React.Component {
+          render() {
+            spy()
+            return <div>hey</div>
+          }
+        }
+        tag(App, 'App')
+
+        const Enhanced = mapProps(props => ({ n: props.n * 5 }))(App)
+        tag(Enhanced, 'Enhanced')
+
+        const wrapper = mount(<AppContainer><Enhanced n={3} /></AppContainer>)
+        expect(wrapper.find('App').length).toBe(1)
+        expect(wrapper.contains(<div>hey</div>)).toBe(true)
+        expect(wrapper.find('App').prop('n')).toBe(15)
+        expect(spy.calls.length).toBe(1)
+      })
+
+      it('force updates the tree on receiving new children', () => {
+        const spy = createSpy()
+        class App extends React.Component {
+          render() {
+            spy()
+            return <div>hey</div>
+          }
+        }
+        tag(App, 'App')
+
+        const Enhanced = mapProps(props => ({ n: props.n * 5 }))(App)
+        tag(Enhanced, 'Enhanced')
+
+        const wrapper = mount(<AppContainer><Enhanced n={3} /></AppContainer>)
+        expect(spy.calls.length).toBe(1)
+
+        {
+          class App extends React.Component {
+            render() {
+              spy()
+              return <div>ho</div>
+            }
+          }
+          tag(App, 'App')
+
+          const Enhanced = mapProps(props => ({ n: props.n * 5 }))(App)
+          tag(Enhanced, 'Enhanced')
+          wrapper.setProps({children: <Enhanced n={3} />})
+        }
+
+        expect(spy.calls.length).toBe(2)
+        expect(wrapper.contains(<div>ho</div>)).toBe(true)
+      })
+
+      it('hot-reloads without losing state', () => {
+        class App extends Component {
+          componentWillMount() {
+            this.state = 'old'
+          }
+
+          shouldComponentUpdate() { return false }
+
+          render() {
+            return <div>old render + {this.state} state + {this.props.n}</div>
+          }
+        }
+        tag(App, 'App')
+
+        const Enhanced = mapProps(props => ({ n: props.n * 5 }))(App)
+        tag(Enhanced, 'Enhanced')
+
+        const wrapper = mount(<AppContainer><Enhanced n={3} /></AppContainer>)
+        expect(wrapper.text()).toBe('old render + old state + 15')
+
+        {
+          class App extends Component {
+            componentWillMount() {
+              this.state = 'new'
+            }
+
+            shouldComponentUpdate() { return false }
+
+            render() {
+              return <div>new render + {this.state} state + {this.props.n}</div>
+            }
+          }
+          tag(App, 'App')
+
+          const Enhanced = mapProps(props => ({ n: props.n * 5 }))(App)
+          tag(Enhanced, 'Enhanced')
+          wrapper.setProps({children: <Enhanced n={4} />})
+        }
+
+        expect(wrapper.text()).toBe('new render + old state + 20')
+      })
+    })
   })
 })


### PR DESCRIPTION
I'll keep this open while I add some more tests.
This also includes moving `deepForceUpdate(this)` to `componentWillReceiveProps`.
I've also removed the tests for receiving the component as prop seeing as that is deprecated.

Todo:
- [x] test with HOC-wrapped component as root

