### PR TITLE
Fixed typo this.props.prop -> this.props.props

### DIFF
--- a/src/AppContainer.prod.js
+++ b/src/AppContainer.prod.js
@@ -8,7 +8,7 @@ const { Component } = React;
 class AppContainer extends Component {
   render() {
     if (this.props.component) {
-      return <this.props.component {...this.props.prop} />;
+      return <this.props.component {...this.props.props} />;
     }
 
     return React.Children.only(this.props.children);


### PR DESCRIPTION
From what I've been able to tell, this was not a bug in 3.0.0-alpha.11 but surfaced in 3.0.0-beta.1