### PR TITLE
Fix a link

### DIFF
--- a/makeExportsHot.js
+++ b/makeExportsHot.js
@@ -44,7 +44,7 @@ function makeExportsHot(m, React) {
       m.exports[key] = m.makeHot(value, '__MODULE_EXPORTS_' + key);
       foundReactClasses = true;
     } else {
-      console.warn("Can't make class " + key + " hot reloadable due to being read-only. To fix this you can try two solutions. First, you can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration. Second, if you are using Babel, you can enable loose mode for `es6.modules` using the 'loose' option. See: http://babeljs.io/docs/advanced/loose/ and http://babeljs.io/docs/usage/options/");
+      console.warn("Can't make class " + key + " hot reloadable due to being read-only. To fix this you can try two solutions. First, you can exclude files or directories (for example, /node_modules/) using 'exclude' option in loader configuration. Second, if you are using Babel, you can enable loose mode for `es6.modules` using the 'loose' option. See: http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/#options-loose and http://babeljs.io/docs/usage/options/");
     }
   }
 


### PR DESCRIPTION
Because http://babeljs.io/docs/advanced/loose/ is `404`