### PR TITLE
Fix RedBox require and add a test

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -2,7 +2,7 @@
 
 const React = require('react');
 const deepForceUpdate = require('react-deep-force-update');
-const Redbox = require('redbox-react');
+const Redbox = require('redbox-react').default;
 const { Component } = React;
 
 class AppContainer extends Component {

--- a/test/AppContainer/AppContainer.dev.js
+++ b/test/AppContainer/AppContainer.dev.js
@@ -1,7 +1,7 @@
 import './setup';
 import React, { Component } from 'react';
 import expect, { createSpy } from 'expect';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { mapProps } from 'recompose';
 
 import AppContainer from '../../src/AppContainer.dev';
@@ -830,6 +830,15 @@ function runAllTests(useWeakMap) {
 
         expect(wrapper.text()).toBe('new render + old state + 20');
       });
+    });
+
+    describe('should use Redbox as the default errorReporter', () => {
+      const wrapper = shallow(<AppContainer><div>hey</div></AppContainer>);
+      const error = new Error('Something is wrong!');
+      wrapper.setState({ error });
+      const errorReporter = wrapper.find('RedBox');
+      expect(errorReporter.length).toBe(1);
+      expect(errorReporter.prop('error')).toBe(error);
     });
   });
 }


### PR DESCRIPTION
This addresses #312 .

Right now in the console we're seeing an error crop up because `AppContainer.dev` is attempting to render the Redbox module export but the component sits on `.default` due to babelification and `AppContainer` is using `require()`.