### PR TITLE
Fix the import of a component from a component with the same base name

### DIFF
--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -45,7 +45,7 @@ function transform(source, map) {
   const separator = '\n\n';
   const appendText = tagCommonJSExportsSource.replace(
     /__FILENAME__/g,
-    JSON.stringify(path.basename(this.resourcePath))
+    JSON.stringify(this.resourcePath)
   );
 
   if (this.sourceMap === false) {


### PR DESCRIPTION
Fix https://github.com/gaearon/react-hot-loader/issues/337, without accessing internal webpack variables.