### PR TITLE
Fixing the broken V3 example in the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,11 +50,12 @@ ReactDOM.render(
 // Hot Module Replacement API
 if (module.hot) {
   module.hot.accept('./containers/App', () => {
-    render(
+    const NextApp = require('./containers/App').default;
+    ReactDOM.render(
       <AppContainer>
-        <App/>
+        <NextApp/>
       </AppContainer>
-      />,
+      ,
       document.getElementById('root')
     );
   });


### PR DESCRIPTION
The V3 docs include a broken example with a hanging "/>" and the incorrect call to ReactDOM.render . The latter cost me an hour to notice. This is a small fix to those small problems.