### PR TITLE
Prevent the Babel plugin from breaking the output of babel-node

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -4,6 +4,9 @@ const buildRegistration = template(
   '__REACT_HOT_LOADER__.register(ID, NAME, FILENAME);'
 );
 const buildSemi = template(';');
+
+// We're making the IIFE we insert at the end of the file an unused variable
+// because it otherwise breaks the output of the babel-node REPL (#359).
 const buildTagger = template(`
 var UNUSED = (function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -5,7 +5,7 @@ const buildRegistration = template(
 );
 const buildSemi = template(';');
 const buildTagger = template(`
-(function () {
+var UNUSED = (function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
@@ -141,7 +141,7 @@ module.exports = function plugin(args) {
           /* eslint-enable */
         },
 
-        exit({ node }) {
+        exit({ node, scope }) {
           const registrations = node[REGISTRATIONS];
           node[REGISTRATIONS] = null; // eslint-disable-line no-param-reassign
 
@@ -150,6 +150,7 @@ module.exports = function plugin(args) {
           node.body.push(buildSemi());
           node.body.push(
             buildTagger({
+              UNUSED: scope.generateUidIdentifier(),
               REGISTRATIONS: registrations,
             })
           );

--- a/test/babel/fixtures/bindings/expected.js
+++ b/test/babel/fixtures/bindings/expected.js
@@ -22,7 +22,7 @@ const _default = React.createClass({});
 export default _default;
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
@@ -38,6 +38,6 @@ export default _default;
   __REACT_HOT_LOADER__.register(E, "E", __FILENAME__);
 
   __REACT_HOT_LOADER__.register(_default, "default", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/arguments/expected.js
+++ b/test/babel/fixtures/class-properties/arguments/expected.js
@@ -8,12 +8,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/block-body/expected.js
+++ b/test/babel/fixtures/class-properties/block-body/expected.js
@@ -10,12 +10,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/default-params/expected.js
+++ b/test/babel/fixtures/class-properties/default-params/expected.js
@@ -10,12 +10,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/destructured-params/expected.js
+++ b/test/babel/fixtures/class-properties/destructured-params/expected.js
@@ -10,12 +10,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/expression-body/expected.js
+++ b/test/babel/fixtures/class-properties/expression-body/expected.js
@@ -10,12 +10,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/nested-arguments/expected.js
+++ b/test/babel/fixtures/class-properties/nested-arguments/expected.js
@@ -10,12 +10,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/nested-new.target/expected.js
+++ b/test/babel/fixtures/class-properties/nested-new.target/expected.js
@@ -9,12 +9,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/class-properties/new.target/expected.js
+++ b/test/babel/fixtures/class-properties/new.target/expected.js
@@ -7,12 +7,12 @@ class Foo {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/counter/expected.js
+++ b/test/babel/fixtures/counter/expected.js
@@ -21,7 +21,7 @@ var _default = function _default() {
 exports.default = _default;
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
@@ -29,6 +29,6 @@ exports.default = _default;
   __REACT_HOT_LOADER__.register(Counter, "Counter", __FILENAME__);
 
   __REACT_HOT_LOADER__.register(_default, "default", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/issue-246/expected.js
+++ b/test/babel/fixtures/issue-246/expected.js
@@ -13,12 +13,12 @@ function spread() {
 }
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
 
   __REACT_HOT_LOADER__.register(spread, "spread", __FILENAME__);
-})();
+}();
 
 ;

--- a/test/babel/fixtures/name-clash/expected.js
+++ b/test/babel/fixtures/name-clash/expected.js
@@ -3,7 +3,7 @@ const _default2 = 42;
 export default _default2;
 ;
 
-(function () {
+var _temp = function () {
   if (typeof __REACT_HOT_LOADER__ === 'undefined') {
     return;
   }
@@ -11,6 +11,6 @@ export default _default2;
   __REACT_HOT_LOADER__.register(_default, "_default", __FILENAME__);
 
   __REACT_HOT_LOADER__.register(_default2, "default", __FILENAME__);
-})();
+}();
 
 ;


### PR DESCRIPTION
Closes #359.

The [tagger code](https://github.com/gaearon/react-hot-loader/blob/bc263de6d123f9f12b5eccfe3054feb948e7a3fd/src/babel/index.js#L7-L15) inserted by the babel plugin at the end of every file is an IIFE, which happens to break `babel-node` output when it's loaded. This happens because the code is added to every line that is evaluated by the REPL, so the lines now end with `(function() { return; })()`, which makes the REPL output `undefined` for every line.

By changing the IIFE from being wrapped in parens to a variable declaration, the output is no longer `undefined` for every line.

The tests pass and from manual testing it doesn't break anything. @nfcampos want to take a look?

Thanks to @loganfsmyth for the help on the Babel slack!