### PR TITLE
Opt out of transforming static class props

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -173,6 +173,11 @@ module.exports = function plugin(args) {
           if (path.isClassProperty()) {
             const { node } = path;
 
+            // don't apply transform to static class properties
+            if (node.static) {
+              return;
+            }
+
             const state = {
               optOut: false,
             };

--- a/test/babel/fixtures/class-properties/static-property/.babelrc
+++ b/test/babel/fixtures/class-properties/static-property/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+}

--- a/test/babel/fixtures/class-properties/static-property/actual.js
+++ b/test/babel/fixtures/class-properties/static-property/actual.js
@@ -1,0 +1,5 @@
+class Foo {
+  static bar = (a, b) => {
+    return a(b);
+  };
+}

--- a/test/babel/fixtures/class-properties/static-property/expected.js
+++ b/test/babel/fixtures/class-properties/static-property/expected.js
@@ -1,0 +1,16 @@
+class Foo {
+  static bar = (a, b) => {
+    return a(b);
+  };
+}
+;
+
+var _temp = function () {
+  if (typeof __REACT_HOT_LOADER__ === 'undefined') {
+    return;
+  }
+
+  __REACT_HOT_LOADER__.register(Foo, "Foo", __FILENAME__);
+}();
+
+;


### PR DESCRIPTION
tests for static class properties and change to opt out of tranforming them. 

I don't think there's any reason for us to transform those, they are already hot reloadable i believe