### PR TITLE
add babel-plugin-transform-class-properties to class-properties babel fixtures

### DIFF
--- a/test/babel/fixtures/class-properties/arguments/.babelrc
+++ b/test/babel/fixtures/class-properties/arguments/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/arguments/expected.js
+++ b/test/babel/fixtures/class-properties/arguments/expected.js
@@ -1,10 +1,12 @@
-var _arguments = arguments;
 class Foo {
-  bar = (a, b) => {
-    _arguments;
+  constructor() {
+    this.bar = (a, b) => {
+      arguments;
 
-    return a(b);
-  };
+      return a(b);
+    };
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/async-functions-expression-body/.babelrc
+++ b/test/babel/fixtures/class-properties/async-functions-expression-body/.babelrc
@@ -1,7 +1,7 @@
 {
   "plugins": [
+    "../../../../../src/babel",
+    "transform-class-properties",
     "syntax-async-functions",
-    "syntax-class-properties",
-    "../../../../../src/babel"
   ]
 }

--- a/test/babel/fixtures/class-properties/async-functions-expression-body/expected.js
+++ b/test/babel/fixtures/class-properties/async-functions-expression-body/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = async (...params) => await _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = async (...params) => await this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   async __bar__REACT_HOT_LOADER__(a, b) {
     return await b(a);

--- a/test/babel/fixtures/class-properties/async-functions/.babelrc
+++ b/test/babel/fixtures/class-properties/async-functions/.babelrc
@@ -1,7 +1,7 @@
 {
   "plugins": [
+    "../../../../../src/babel",
+    "transform-class-properties",
     "syntax-async-functions",
-    "syntax-class-properties",
-    "../../../../../src/babel"
   ]
 }

--- a/test/babel/fixtures/class-properties/async-functions/expected.js
+++ b/test/babel/fixtures/class-properties/async-functions/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = async (...params) => await _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = async (...params) => await this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   async __bar__REACT_HOT_LOADER__(a, b) {
     return await a(b);

--- a/test/babel/fixtures/class-properties/block-body/.babelrc
+++ b/test/babel/fixtures/class-properties/block-body/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/block-body/expected.js
+++ b/test/babel/fixtures/class-properties/block-body/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = (...params) => _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   __bar__REACT_HOT_LOADER__(a, b) {
     return a(b);

--- a/test/babel/fixtures/class-properties/default-params/.babelrc
+++ b/test/babel/fixtures/class-properties/default-params/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/default-params/expected.js
+++ b/test/babel/fixtures/class-properties/default-params/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = (...params) => _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   __bar__REACT_HOT_LOADER__(a = "foo") {
     return `${ a }bar`;

--- a/test/babel/fixtures/class-properties/destructured-params/.babelrc
+++ b/test/babel/fixtures/class-properties/destructured-params/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/destructured-params/expected.js
+++ b/test/babel/fixtures/class-properties/destructured-params/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = (...params) => _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   __bar__REACT_HOT_LOADER__({ a }, { b }) {
     return `${ a }${ b }`;

--- a/test/babel/fixtures/class-properties/expression-body/.babelrc
+++ b/test/babel/fixtures/class-properties/expression-body/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/expression-body/expected.js
+++ b/test/babel/fixtures/class-properties/expression-body/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  onClick = (...params) => _this.__onClick__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.onClick = (...params) => this.__onClick__REACT_HOT_LOADER__(...params);
+  }
 
   __onClick__REACT_HOT_LOADER__(e) {
     return e.target.value;

--- a/test/babel/fixtures/class-properties/nested-arguments/.babelrc
+++ b/test/babel/fixtures/class-properties/nested-arguments/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/nested-arguments/expected.js
+++ b/test/babel/fixtures/class-properties/nested-arguments/expected.js
@@ -1,12 +1,14 @@
-var _arguments = arguments;
 class Foo {
-  bar = (a, b) => {
-    () => {
-      _arguments;
-    };
+  constructor() {
+    this.bar = (a, b) => {
+      () => {
+        arguments;
+      };
 
-    return a(b);
-  };
+      return a(b);
+    };
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/nested-new.target/.babelrc
+++ b/test/babel/fixtures/class-properties/nested-new.target/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/nested-new.target/expected.js
+++ b/test/babel/fixtures/class-properties/nested-new.target/expected.js
@@ -1,11 +1,14 @@
 class Foo {
-  bar = (a, b) => {
-    () => {
-      new.target;
-    };
+  constructor() {
+    this.bar = (a, b) => {
+      () => {
+        new.target;
+      };
 
-    return a(b);
-  };
+      return a(b);
+    };
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/new.target/.babelrc
+++ b/test/babel/fixtures/class-properties/new.target/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/new.target/expected.js
+++ b/test/babel/fixtures/class-properties/new.target/expected.js
@@ -1,9 +1,12 @@
 class Foo {
-  bar = (a, b) => {
-    new.target;
+  constructor() {
+    this.bar = (a, b) => {
+      new.target;
 
-    return a(b);
-  };
+      return a(b);
+    };
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/not-a-function/.babelrc
+++ b/test/babel/fixtures/class-properties/not-a-function/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/not-a-function/expected.js
+++ b/test/babel/fixtures/class-properties/not-a-function/expected.js
@@ -1,5 +1,8 @@
 class Foo {
-  bar = 2;
+  constructor() {
+    this.bar = 2;
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/not-an-arrow-function/.babelrc
+++ b/test/babel/fixtures/class-properties/not-an-arrow-function/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/not-an-arrow-function/expected.js
+++ b/test/babel/fixtures/class-properties/not-an-arrow-function/expected.js
@@ -1,7 +1,10 @@
 class Foo {
-  bar = function (a, b) {
-    return a(b);
-  };
+  constructor() {
+    this.bar = function (a, b) {
+      return a(b);
+    };
+  }
+
 }
 ;
 

--- a/test/babel/fixtures/class-properties/same-name-as-class-method/.babelrc
+++ b/test/babel/fixtures/class-properties/same-name-as-class-method/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/same-name-as-class-method/expected.js
+++ b/test/babel/fixtures/class-properties/same-name-as-class-method/expected.js
@@ -1,7 +1,7 @@
-var _this = this;
-
 class Foo {
-  bar = (...params) => _this.__bar__REACT_HOT_LOADER__(...params);
+  constructor() {
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+  }
 
   __bar__REACT_HOT_LOADER__(a, b) {
     return a(b);

--- a/test/babel/fixtures/class-properties/static-property/.babelrc
+++ b/test/babel/fixtures/class-properties/static-property/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["syntax-class-properties", "../../../../../src/babel"]
+  "plugins": ["../../../../../src/babel", "transform-class-properties"]
 }

--- a/test/babel/fixtures/class-properties/static-property/expected.js
+++ b/test/babel/fixtures/class-properties/static-property/expected.js
@@ -1,8 +1,9 @@
-class Foo {
-  static bar = (a, b) => {
-    return a(b);
-  };
-}
+class Foo {}
+
+Foo.bar = (a, b) => {
+  return a(b);
+};
+
 ;
 
 var _temp = function () {


### PR DESCRIPTION
- using only babel-plugin-syntax-class-properties produces invalid output, see https://github.com/gaearon/react-hot-loader/pull/322#discussion_r82390063