### PR TITLE
Use production patch/AppContainer if no module.hot

### DIFF
--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-if (!module.hot && process.env.NODE_ENV === 'production') {
+if (!module.hot || process.env.NODE_ENV === 'production') {
   module.exports = require('./AppContainer.prod');
 } else {
   module.exports = require('./AppContainer.dev');

--- a/src/patch.js
+++ b/src/patch.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-if (!module.hot && process.env.NODE_ENV === 'production') {
+if (!module.hot || process.env.NODE_ENV === 'production') {
   module.exports = require('./patch.prod');
 } else {
   module.exports = require('./patch.dev');


### PR DESCRIPTION
Prevents cases where things like `NODE_ENV=test` import the development `AppContainer`
and patching code. I left the `NODE_ENV=production` check in for manually opting out. Closes #396.