### PR TITLE
Remove deprecations from AppContainer

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -52,36 +52,11 @@ class AppContainer extends Component {
       return <this.props.errorReporter error={error} />;
     }
 
-    if (this.props.component) {
-      return <this.props.component {...this.props.props} />;
-    }
-
     return React.Children.only(this.props.children);
   }
 }
 
 AppContainer.propTypes = {
-  component(props) {
-    if (props.component) {
-      return new Error(
-        'Passing "component" prop to <AppContainer /> is deprecated. ' +
-        'Replace <AppContainer component={App} /> with <AppContainer><App /></AppContainer>.'
-      );
-    }
-
-    return undefined;
-  },
-  props(props) {
-    if (props.props) {
-      return new Error(
-        'Passing "props" prop to <AppContainer /> is deprecated. ' +
-        'Replace <AppContainer component={App} props={{ myProp: myValue }} /> ' +
-        'with <AppContainer><App myProp={myValue} /></AppContainer>.'
-      );
-    }
-
-    return undefined;
-  },
   children(props) {
     if (React.Children.count(props.children) !== 1) {
       return new Error(


### PR DESCRIPTION
In the alpha versions of 3.0, `AppContainer` accepted [the child component and its props as props](https://github.com/gaearon/redux-devtools/blob/64f58b7010a1b2a71ad16716eb37ac1031f93915/examples/todomvc/index.js), but we moved to passing [a single child](https://github.com/gaearon/react-hot-loader/blob/644d4f35ae65a6eddeee39945adfdaa01f6fc660/docs/README.md) in the beta.

The beta's been out for a while, and I haven't seen anyone using the alpha examples recently, so I'd say it's safe to remove these deprecations (we're still in beta after all).