### PR TITLE
Add environment-specific importing for index.js

### DIFF
--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const AppContainer = require('./AppContainer');
+
+module.exports = function warnAboutIncorrectUsage(arg) {
+  if (this && this.callback) {
+    throw new Error(
+      'React Hot Loader: The Webpack loader is now exported separately. ' +
+      'If you use Babel, we recommend that you remove "react-hot-loader" ' +
+      'from the "loaders" section of your Webpack configuration altogether, ' +
+      'and instead add "react-hot-loader/babel" to the "plugins" section ' +
+      'of your .babelrc file. ' +
+      'If you prefer not to use Babel, replace "react-hot-loader" or ' +
+      '"react-hot" with "react-hot-loader/webpack" in the "loaders" section ' +
+      'of your Webpack configuration.'
+    );
+  } else if (arg && arg.types && arg.types.IfStatement) {
+    throw new Error(
+      'React Hot Loader: The Babel plugin is exported separately. ' +
+      'Replace "react-hot-loader" with "react-hot-loader/babel" ' +
+      'in the "plugins" section of your .babelrc file. ' +
+      'While we recommend the above, if you prefer not to use Babel, ' +
+      'you may remove "react-hot-loader" from the "plugins" section of ' +
+      'your .babelrc file altogether, and instead add ' +
+      '"react-hot-loader/webpack" to the "loaders" section of your Webpack ' +
+      'configuration.'
+    );
+  } else {
+    throw new Error(
+      'React Hot Loader does not have a default export. ' +
+      'If you use the import statement, make sure to include the ' +
+      'curly braces: import { AppContainer } from "react-hot-loader". ' +
+      'If you use CommonJS, make sure to read the named export: ' +
+      'require("react-hot-loader").AppContainer.'
+    );
+  }
+};
+
+module.exports.AppContainer = AppContainer;

--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,9 @@
+/* eslint-disable global-require */
+
 'use strict';
 
-const AppContainer = require('./AppContainer');
-
-module.exports = function warnAboutIncorrectUsage(arg) {
-  if (this && this.callback) {
-    throw new Error(
-      'React Hot Loader: The Webpack loader is now exported separately. ' +
-      'If you use Babel, we recommend that you remove "react-hot-loader" ' +
-      'from the "loaders" section of your Webpack configuration altogether, ' +
-      'and instead add "react-hot-loader/babel" to the "plugins" section ' +
-      'of your .babelrc file. ' +
-      'If you prefer not to use Babel, replace "react-hot-loader" or ' +
-      '"react-hot" with "react-hot-loader/webpack" in the "loaders" section ' +
-      'of your Webpack configuration.'
-    );
-  } else if (arg && arg.types && arg.types.IfStatement) {
-    throw new Error(
-      'React Hot Loader: The Babel plugin is exported separately. ' +
-      'Replace "react-hot-loader" with "react-hot-loader/babel" ' +
-      'in the "plugins" section of your .babelrc file. ' +
-      'While we recommend the above, if you prefer not to use Babel, ' +
-      'you may remove "react-hot-loader" from the "plugins" section of ' +
-      'your .babelrc file altogether, and instead add ' +
-      '"react-hot-loader/webpack" to the "loaders" section of your Webpack ' +
-      'configuration.'
-    );
-  } else {
-    throw new Error(
-      'React Hot Loader does not have a default export. ' +
-      'If you use the import statement, make sure to include the ' +
-      'curly braces: import { AppContainer } from "react-hot-loader". ' +
-      'If you use CommonJS, make sure to read the named export: ' +
-      'require("react-hot-loader").AppContainer.'
-    );
-  }
-};
-
-module.exports.AppContainer = AppContainer;
+if (!module.hot || process.env.NODE_ENV === 'production') {
+  module.exports = require('./index.prod');
+} else {
+  module.exports = require('./index.dev');
+}

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.AppContainer = require('./AppContainer');


### PR DESCRIPTION
This removes a few of the error messages from production builds that are only applicable in
development, which saves a few bytes. Closes #420.