### PR TITLE
(1.3) Fix ReactMount import for React 15.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,22 @@ module.exports = function (source, map) {
       node,
       result;
 
+  var reactMountImport;
+  try {
+    require('react-dom/lib/ReactMount');
+    reactMountImport = 'ReactMount = require("react-dom/lib/ReactMount"),';
+} catch(e) {
+    console.log(e)
+    reactMountImport = 'ReactMount = require("react/lib/ReactMount"),';
+  }
+
   prependText = [
     '/* REACT HOT LOADER */',
     'if (module.hot) {',
       '(function () {',
         'var ReactHotAPI = require(' + JSON.stringify(require.resolve('react-hot-api')) + '),',
             'RootInstanceProvider = require(' + JSON.stringify(require.resolve('./RootInstanceProvider')) + '),',
-            'ReactMount = require("react/lib/ReactMount"),',
+            reactMountImport,
             'React = require("react");',
 
         'module.makeHot = module.hot.data ? module.hot.data.makeHot : ReactHotAPI(function () {',

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = function (source, map) {
     require('react-dom/lib/ReactMount');
     reactMountImport = 'ReactMount = require("react-dom/lib/ReactMount"),';
 } catch(e) {
-    console.log(e)
     reactMountImport = 'ReactMount = require("react/lib/ReactMount"),';
   }
 


### PR DESCRIPTION
**Please Note: this is a breakfix because this broke a many people's apps and will probably be the last 1.x fix.**

This will still support pre-15.4 by using a try-catch and adding the correct
import statement based on whether importing it from `react-dom` (the new
way) fails.

I've tested this with React 15.4, 15.3, and 0.14.

