### PR TITLE
Installing a next version of react-hot-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 >## A Big Update Is Coming
 
->React Hot Loader 3 is [on the horizon](https://github.com/gaearon/react-hot-loader/pull/240), and you can try it today ([boilerplate branch](https://github.com/gaearon/react-hot-boilerplate/pull/61), [upgrade example](https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915)). It fixes some [long-standing issues](https://twitter.com/dan_abramov/status/722040946075045888) with both React Hot Loader and React Transform, and is intended as a replacement for both. The docs are not there yet, but they will be added before the final release. For now, [this commit](https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915) is a good reference.
+>React Hot Loader 3 is [on the horizon](https://github.com/gaearon/react-hot-loader/pull/240), and you can try it today ([boilerplate branch](https://github.com/gaearon/react-hot-boilerplate/pull/61), [upgrade example](https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915)). It fixes some [long-standing issues](https://twitter.com/dan_abramov/status/722040946075045888) with both React Hot Loader and React Transform, and is intended as a replacement for both. The docs are not there yet, but they will be added before the final release. For now, [this commit](https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915) is a good reference.You can install RHL3 using `npm install --save-dev react-hot-loader@next`
 
 # React Hot Loader [![npm package](https://img.shields.io/npm/v/react-hot-loader.svg?style=flat-square)](https://www.npmjs.org/package/react-hot-loader)
 
@@ -19,7 +19,7 @@ Watch **[Dan Abramov's talk on Hot Reloading with Time Travel](https://www.youtu
 
 ## Installation
 
-`npm install --save-dev react-hot-loader@next`
+`npm install --save-dev react-hot-loader`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Watch **[Dan Abramov's talk on Hot Reloading with Time Travel](https://www.youtu
 
 ## Installation
 
-`npm install --save-dev react-hot-loader`
+`npm install --save-dev react-hot-loader@next`
 
 ## Usage
 


### PR DESCRIPTION
`npm install --save-dev react-hot-loader` installs 1.3.0 version so changing it to `npm install --save-dev react-hot-loader@next`, after merging to master need to revert back.