### PR TITLE
Update Troubleshooting.md

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -53,7 +53,7 @@ If you used WebpackDevServer CLI mode and after switching to Node it crashes wit
 
 ### Module not found: Error: Cannot resolve module 'react-hot'
 
-Most likely you used `npm link` to use a development version of a package in a different folder, and React Hot Loader processed it by mistake. You should use [`include` in loader configuration](https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L27) to only opt-in your app's files to processing.
+Most likely you used `npm link` to use a development version of a package in a different folder, and React Hot Loader processed it by mistake. You should use [`include` in loader configuration](https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L22) to only opt-in your app's files to processing.
 
 ---------
 


### PR DESCRIPTION
Just a small change I noticed when I was problem solving a npm link issue with react-hot-loader. https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L27 (line 27) no longer exists, pretty sure it is https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L22.
Cheers