### PR TITLE
fix: use relative file path instead of absolute

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -124,7 +124,7 @@ module.exports = function plugin(args) {
           buildRegistration({
             ID: id,
             NAME: t.stringLiteral('default'),
-            FILENAME: t.stringLiteral(file.opts.filename),
+            FILENAME: t.stringLiteral('./' + file.opts.sourceFileName),
           })
         );
       },
@@ -142,7 +142,7 @@ module.exports = function plugin(args) {
               node[REGISTRATIONS].push(buildRegistration({
                 ID: binding.identifier,
                 NAME: t.stringLiteral(id),
-                FILENAME: t.stringLiteral(file.opts.filename),
+                FILENAME: t.stringLiteral('./' + file.opts.sourceFileName),
               }));
             }
           }


### PR DESCRIPTION
In my case, react-hot-loader register my files with the absolute path. webpack-hot-middleware uses relative path, so hot reload don't work.

```js
  __REACT_HOT_LOADER__.register(init, 'init', '/Users/..../app/src/index.js');
```

This patch fix it: 

```js
  __REACT_HOT_LOADER__.register(init, 'init', './src/index.js');
```

Or is there another way to fix it ?