### PR TITLE
AppContainer handleError output on console

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -41,6 +41,7 @@ class AppContainer extends Component {
   // Later it will work for updates as well:
   // https://github.com/facebook/react/pull/6020
   unstable_handleError(error) { // eslint-disable-line camelcase
+    console.error(error);
     this.setState({
       error,
     });


### PR DESCRIPTION
handleError captures the error and render it, not allowing the error to be printed on console.
Rendering error is beautiful, but not functional. Console prints stacktrace with clickable links and translating lines to original source with sourcemaps.