### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check out [the Migration to 3.0 guide](https://github.com/gaearon/react-hot-load
 
 ## Installation
 
-`npm install --save-dev react-hot-loader@next`
+`npm install --save react-hot-loader@next`
 
 ## Usage
 


### PR DESCRIPTION
- The installation instructions indicate that
  react-hot-loader should be installed as a
  dev dependency, however, since it is used
  in production when checking if module.hot,
  it should be pulled in as a dependency with
  the save flag.

This one threw me for a loop when I was running it in my environment and I wanted to make sure others are properly adding it as a dependency to their project.

See discussion and reference PR's:
https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915
https://github.com/gaearon/redux-devtools/pull/280/files

![image](https://cloud.githubusercontent.com/assets/7675942/23923493/1a24070a-08c4-11e7-8ea0-b188b50a6a6c.png)

