### PR TITLE
Add Browserify boilerplates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ These steps are covered by **[the Migration to 3.0 guide](https://github.com/gae
 
 If you'd rather stay with **Browserify**, check out **[LiveReactload](https://github.com/milankinen/livereactload)** by Matti Lankinen.
 
+Forks of the above Boilerplates using **Browserify** instead:
+
+- **[React Hot Browserify Boilerplate](https://github.com/EugeneZ/react-hot-browserify-boilerplate/tree/next)**
+- **[React Hot Loader Browserify Minimal Boilerplate](https://github.com/EugeneZ/react-hot-loader-browserify-minimal-boilerplate)**
+
 ## Known limitations
 
 - React Router v3 is not fully supported (e.g. async routes). If you want to get most of React Hot Loader, consider switching to [React Router v4](https://reacttraining.com/react-router/). If you want to understand the reasoning, it's good to start in [React Router v4 FAQ](https://github.com/ReactTraining/react-router/tree/v4.0.0-beta.8#v4-faq)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ Provided by community:
 * [react-universal-hot-loader-starter-kit](https://github.com/earnubs/react-hot-loader-starter-kit) (universal express app with webpack 2, react-router 4, redux and react-hot-loader 3)
 * [bare-minimum-react-hot-rr4-redux](https://github.com/nganbread/bare-minimum-react-hot-rr4-redux) (Bare minimum webpack 2, react-router 4, redux)
 * [react-webpack2-boilerplate](https://github.com/plag/react-webpack2-boilerplate/) (Minimal react-router-3, react-redux, redux-saga on webpack2 with full hot reloading include reducers, sagas and react-components)
+* [react-hot-browserify-boilerplate](https://github.com/EugeneZ/react-hot-browserify-boilerplate/tree/next)
+* [react-hot-loader-browserify-minimal-boilerplate](https://github.com/EugeneZ/react-hot-loader-browserify-minimal-boilerplate)
 
 ### Migration to 3.0
 - If you're using Babel and ES6, remove the `react-hot` loader from any loaders in your Webpack config, and add `react-hot-loader/babel` to the `plugins` section of your `.babelrc`:


### PR DESCRIPTION
LiveReactload has a beta out that supports the new `react-hot-loader` and it works great! Adding a few boilerplates to the README can help people figure out where to start if they use Browserify.