### PR TITLE
replace 0x2019 character with regular single quote

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -61,7 +61,7 @@ AppContainer.propTypes = {
     if (React.Children.count(props.children) !== 1) {
       return new Error(
         'Invalid prop "children" supplied to AppContainer. ' +
-        'Expected a single React element with your app’s root component, e.g. <App />.'
+        'Expected a single React element with your app\'s root component, e.g. <App />.'
       );
     }
 


### PR DESCRIPTION
The console error message was using a right-quote [’] character instead of the normal [']. In my situation (piping from webpack to ASP.NET) the quote was then getting automatically converted into a regular quote and this was causing the source file itself to be invalid.

I need to find out exactly why this was happening on my end, but to avoid similar situations in the future I would suggest changing it to a regular quote.