### PR TITLE
fixes React.PropTypes deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,10 @@
     "expect": "^1.16.0",
     "jsdom": "^8.4.1",
     "mocha": "^2.4.5",
-    "react": "^15.0.2",
+    "proptypes": "0.14.4",
+    "react": "15.5.3",
     "react-addons-test-utils": "^15.0.2",
-    "react-dom": "^15.0.2",
+    "react-dom": "15.5.3",
     "recompose": "^0.17.0",
     "rimraf": "^2.5.2"
   },

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -2,6 +2,7 @@
 
 const React = require('react');
 const deepForceUpdate = require('react-deep-force-update');
+const propTypes = require('prop-types'); // eslint-disable-line
 const Redbox = require('redbox-react').default;
 const { Component } = React;
 


### PR DESCRIPTION
# What did I do to the code base

- [x] bumped `react` & `react-dom` to `v15.5.3`.
- [x] added `prop-types` as _devDep_.
- [x] used `prop-types` package in `./src/AppContainer.dev.js`.

Passed all tests & linting locally. Made a test repo for testing changes live. Ran from `react-hot-loader` directory locally with no issues. Repo can be found [here](https://github.com/rockchalkwushock/test-playground).

Any further changes or comments please feel free to reach out! This is my first time contributing 😟 

Fixes #541 