### PR TITLE
Upgrade redbox-react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "global": "^4.3.0",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^3.0.0-alpha.0",
-    "redbox-react": "^1.2.5",
+    "redbox-react": "^1.3.6",
     "source-map": "^0.4.4"
   },
   "repository": {


### PR DESCRIPTION
To fix `prop-types` deprecation errors.
Tests run locally