### PR TITLE
fix: apply the current scope when invoking a function (fixes #554)

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -19,8 +19,14 @@ var UNUSED = (function () {
 
 const buildNewClassProperty = (t, classPropertyName, newMethodName, isAsync) => {
   let returnExpression = t.callExpression(
-    t.memberExpression(t.thisExpression(), newMethodName),
-    [t.spreadElement(t.identifier('params'))]
+    t.memberExpression(
+      t.memberExpression(t.thisExpression(), newMethodName),
+      t.identifier('apply')
+    ),
+    [
+      t.thisExpression(),
+      t.identifier('params'),
+    ]
   );
 
   if (isAsync) {

--- a/test/babel/fixtures/class-properties/block-body/expected.js
+++ b/test/babel/fixtures/class-properties/block-body/expected.js
@@ -1,6 +1,6 @@
 class Foo {
   constructor() {
-    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__.apply(this, params);
   }
 
   __bar__REACT_HOT_LOADER__(a, b) {

--- a/test/babel/fixtures/class-properties/default-params/expected.js
+++ b/test/babel/fixtures/class-properties/default-params/expected.js
@@ -1,6 +1,6 @@
 class Foo {
   constructor() {
-    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__.apply(this, params);
   }
 
   __bar__REACT_HOT_LOADER__(a = "foo") {

--- a/test/babel/fixtures/class-properties/destructured-params/expected.js
+++ b/test/babel/fixtures/class-properties/destructured-params/expected.js
@@ -1,6 +1,6 @@
 class Foo {
   constructor() {
-    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__.apply(this, params);
   }
 
   __bar__REACT_HOT_LOADER__({ a }, { b }) {

--- a/test/babel/fixtures/class-properties/expression-body/expected.js
+++ b/test/babel/fixtures/class-properties/expression-body/expected.js
@@ -1,6 +1,6 @@
 class Foo {
   constructor() {
-    this.onClick = (...params) => this.__onClick__REACT_HOT_LOADER__(...params);
+    this.onClick = (...params) => this.__onClick__REACT_HOT_LOADER__.apply(this, params);
   }
 
   __onClick__REACT_HOT_LOADER__(e) {

--- a/test/babel/fixtures/class-properties/same-name-as-class-method/expected.js
+++ b/test/babel/fixtures/class-properties/same-name-as-class-method/expected.js
@@ -1,6 +1,6 @@
 class Foo {
   constructor() {
-    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__(...params);
+    this.bar = (...params) => this.__bar__REACT_HOT_LOADER__.apply(this, params);
   }
 
   __bar__REACT_HOT_LOADER__(a, b) {


### PR DESCRIPTION
* fixes #554
* maybe fixes #391