### PR TITLE
allow output error message to browser console panel

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -23,15 +23,6 @@ class AppContainer extends Component {
     this.setHandleError(props);
   }
 
-  setHandleError(props) {
-    const handleError = props.handleError;
-    if (handleError) {
-      this.unstable_handleError = unstable_handleError;
-    } else {
-      delete this.unstable_handleError;
-    }
-  }
-
   componentDidMount() {
     if (typeof __REACT_HOT_LOADER__ === 'undefined') {
       console.error(
@@ -58,6 +49,15 @@ class AppContainer extends Component {
     // Force-update the whole tree, including
     // components that refuse to update.
     deepForceUpdate(this);
+  }
+
+  setHandleError(props) {
+    const handleError = props.handleError;
+    if (handleError) {
+      this.unstable_handleError = unstable_handleError;
+    } else {
+      delete this.unstable_handleError;
+    }
   }
 
   render() {

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -9,7 +9,7 @@ const { Component } = React;
 // In 15.0, it only catches errors on initial mount.
 // Later it will work for updates as well:
 // https://github.com/facebook/react/pull/6020
-function unstable_handleError(error) { // eslint-disable-line camelcase
+function unstableHandleError(error) { // eslint-disable-line camelcase
   this.setState({
     error,
   });
@@ -54,7 +54,7 @@ class AppContainer extends Component {
   setHandleError(props) {
     const handleError = props.handleError;
     if (handleError) {
-      this.unstable_handleError = unstable_handleError;
+      this.unstable_handleError = unstableHandleError;
     } else {
       delete this.unstable_handleError;
     }


### PR DESCRIPTION
```javascript
<AppContainer handleError={false}>...</AppContainer> //=> output error message on console panel
<AppContainer>...<AppContainer/> or <AppContainer handleError={true}>...</AppContainer> //=> output error message on Redbox
``` 