### PR TITLE
Fixed test execution on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Comparison tests were failed due to line endings: `babel` produces JS-files with LF, but `git` checkouts all text files with OS default line endings (CRLF for Windows).

Now `git` is forced to checkout JS-files with LF.