### PR TITLE
Updated Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-react": "^5.0.1",
     "expect": "^1.16.0",
     "jsdom": "^8.4.1",
-    "mocha": "^2.4.5",
+    "mocha": "^3.4.1",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",


### PR DESCRIPTION
npm installs were throwing a lot of warnings for deprecated dependencies. Updating mocha fixed it easily.