### PR TITLE
Adding another possible error message to the Troubleshooting.md

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -60,6 +60,9 @@ Most likely you used `npm link` to use a development version of a package in a d
 ### Page Throws an Error
 
 #### Uncaught TypeError: Cannot read property 'NODE_ENV' of undefined
+
+#### Uncaught TypeError: Cannot read property 'env' of undefined
+
 #### [socket.io] Cannot use 'in' operator to search for 'document' in undefined
 
 Make sure you have `exclude: /node_modules/` or, better, `include: path.join(__dirname, 'src')` (path depends on your application) in loader configuration [just like on this line](https://github.com/gaearon/react-hot-boilerplate/blob/fbdbd93956241320bc3960d350c4dd0030cc6e84/webpack.config.js#L27). You never need to process `node_modules` with React Hot Loader. If you use other loaders such as `jsx?harmony` or `babel`, most likely they **also** need to have `include` specified.


### PR DESCRIPTION
I was debugging this error:
   
    (function register() { /* react-hot-loader/webpack */ if (process.env.NODE_ENV !== 'production') { if (...

The above was running on my browser. `process` was, of course, undefined, so `env` couldn't be read.

The given solution for the message `Uncaught TypeError: Cannot read property 'NODE_ENV' of undefined`, described in this document, was also the solution for my message, which was `Uncaught TypeError: Cannot read property 'env' of undefined` so I decided to contribute to this document.