### PR TITLE
Update readme about create-react-app migration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,7 @@ Hot reloading code is just one line in the beginning and one line in the end of 
        'react-hot-loader/patch',
        require.resolve('react-dev-utils/webpackHotDevClient'),
        require.resolve('./polyfills'),
+       require.resolve('react-error-overlay'),
        paths.appIndexJs
     ]
   ```
@@ -160,21 +161,23 @@ Hot reloading code is just one line in the beginning and one line in the end of 
   2. Add `'react-hot-loader/babel'` to Babel loader configuration. The loader should now look like:
   ```js
     {
-       test: /\.(js|jsx)$/,
-       include: paths.appSrc,
-       loader: 'babel',
-       query: {
-         cacheDirectory: findCacheDir({
-           name: 'react-scripts'
-         }),
-         plugins: [
-           'react-hot-loader/babel'
-         ]
-       }
-    }
+      test: /\.(js|jsx)$/,
+      include: paths.appSrc,
+      loader: require.resolve('babel-loader'),
+      options: {
+
+        // This is a feature of `babel-loader` for webpack (not Babel itself).
+        // It enables caching results in ./node_modules/.cache/babel-loader/
+        // directory for faster rebuilds.
+        cacheDirectory: true,
+        plugins: [
+          'react-hot-loader/babel'
+        ],
+      },
+    },
   ```
 
-* Add `AppContainer` to `src/index.js` (see `AppContainer` section in [Migration to 3.0 above](https://github.com/gaearon/react-hot-loader/blob/next-docs/docs/README.md#migration-to-30))
+* Add `AppContainer` to `src/index.js` (see `AppContainer` section in [Webpack 2](#webpack-2) above)
 
 ## TypeScript
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,10 +165,6 @@ Hot reloading code is just one line in the beginning and one line in the end of 
       include: paths.appSrc,
       loader: require.resolve('babel-loader'),
       options: {
-
-        // This is a feature of `babel-loader` for webpack (not Babel itself).
-        // It enables caching results in ./node_modules/.cache/babel-loader/
-        // directory for faster rebuilds.
         cacheDirectory: true,
         plugins: [
           'react-hot-loader/babel'

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,11 +150,11 @@ Hot reloading code is just one line in the beginning and one line in the end of 
   1. Add `'react-hot-loader/patch'` to entry array (anywhere before `paths.appIndexJs`). It should now look like (excluding comments):
   ```js
     entry: [
-       'react-hot-loader/patch',
-       require.resolve('react-dev-utils/webpackHotDevClient'),
-       require.resolve('./polyfills'),
-       require.resolve('react-error-overlay'),
-       paths.appIndexJs
+      'react-hot-loader/patch',
+      require.resolve('react-dev-utils/webpackHotDevClient'),
+      require.resolve('./polyfills'),
+      require.resolve('react-error-overlay'),
+      paths.appIndexJs
     ]
   ```
 


### PR DESCRIPTION
As create-react-app released with webpack 2, there are little changes.