### PR TITLE
Update to latest redbox-react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "global": "^4.3.0",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^3.0.0-alpha.0",
-    "redbox-react": "^1.2.5",
+    "redbox-react": "^1.4.0",
     "source-map": "^0.4.4"
   },
   "repository": {


### PR DESCRIPTION
There's a noisy console error due to deprecated React.PropTypes in redbox-react. They have fixed it in later versions so react-hot-loader should use the latest version.

From #541