### PR TITLE
Remove babel polyfill

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,6 @@ Provided by community:
 {
   entry: {
     'app': [
-      'babel-polyfill',
       'react-hot-loader/patch',
       './src/index'
     ]


### PR DESCRIPTION
Hey,

I removed this value because I think it is not related with the hot loader configuration and causes confusion.

Nowadays, probably better load babel using `babel-preset-env` and it's lived at `.babelrc`

```json
"presets": [
    [
      "env",
      {
        "modules": false,
        "targets": {"browsers": ["last 2 versions", "ie >= 9"]}
      }
    ],
    "react"
  ],
```

so probably, could be possible you are wrongly loading babel twice times.

Please, correct me if I'm wrong 😄. If you confirme my words, I can make another PR for suggest how to load babel using `babelrc` or `webpack`.