### PR TITLE
Upgrade source-map to v0.5.6. This change fixes #603 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "react-hot-api": "^0.4.5",
-    "source-map": "^0.4.4"
+    "source-map": "^0.5.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi! With the recent upgrade to webpack v3.x I faced with an error:
```javascript
source-map-generator.js:8 Uncaught Error: Cannot find module "."
    at webpackMissingModule (source-map-generator.js:8)
    at Object.eval (source-map-generator.js:8)
    at eval (source-map-generator.js:401)
    at Object.<anonymous> (dllVendor.js:5383)
    at __webpack_require__ (dllVendor.js:21)
    at eval (source-map.js:6)
    at Object.<anonymous> (dllVendor.js:1402)
    at __webpack_require__ (dllVendor.js:21)
    at eval (index.js:4)
    at Object.<anonymous> (dllVendor.js:5371)
```
I did some research and found out that this error comes from `react-hot-loader`. 
So I tested it manually in my project, and the issue is gone with the latest version of `source-map` module.

This change should fix #603 issue.