### PR TITLE
feat(AppContainer): support componentDidCatch for React v16

### DIFF
--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -41,6 +41,10 @@ class AppContainer extends Component {
   // Later it will work for updates as well:
   // https://github.com/facebook/react/pull/6020
   unstable_handleError(error) { // eslint-disable-line camelcase
+    this.componentDidCatch(error);
+  }
+
+  componentDidCatch(error) {
     this.setState({
       error,
     });


### PR DESCRIPTION
Add support for React v16 `componentDidCatch`, and proxy to that from React v15 `unstable_handleError`.