### PR TITLE
Fix #548

### DIFF
--- a/src/webpack/tagCommonJSExports.js
+++ b/src/webpack/tagCommonJSExports.js
@@ -7,19 +7,25 @@
       return;
     }
 
-    if (typeof module.exports === 'function') {
-      __REACT_HOT_LOADER__.register(module.exports, 'module.exports', __FILENAME__);
+    /* eslint-disable camelcase, no-undef */
+    const webpackExports = typeof __webpack_exports__ !== 'undefined'
+      ? __webpack_exports__
+      : module.exports;
+    /* eslint-enable camelcase, no-undef */
+
+    if (typeof webpackExports === 'function') {
+      __REACT_HOT_LOADER__.register(webpackExports, 'module.exports', __FILENAME__);
       return;
     }
 
-    for (const key in module.exports) { // eslint-disable-line no-restricted-syntax
-      if (!Object.prototype.hasOwnProperty.call(module.exports, key)) {
+    for (const key in webpackExports) { // eslint-disable-line no-restricted-syntax
+      if (!Object.prototype.hasOwnProperty.call(webpackExports, key)) {
         continue;
       }
 
       let namedExport;
       try {
-        namedExport = module.exports[key];
+        namedExport = webpackExports[key];
       } catch (err) {
         continue;
       }


### PR DESCRIPTION
When compiling with ES2015 modules, webpack stores them into ```__webpack_exports__``` variable instead of ```module.exports``` which will be undefined, thus registration won't occur. 

Tested with TS/Webpack3 and both commonjs/es2015 module output.

I'm not sure what this is correct way to fix

Fixes #548