### PR TITLE
Remove proptypes from generated code.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,9 @@
 {
   "presets": ["env", "react"],
-  "plugins": ["transform-class-properties"],
+  "plugins": [
+    "transform-class-properties",
+    "transform-react-remove-prop-types"
+  ],
   "env": {
     "test": {
       "plugins": ["transform-class-properties", "./lib/babel"]

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-eslint": "^8.0.0",
     "babel-jest": "^21.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+		"babel-plugin-transform-react-remove-prop-types": "^0.4.9",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.5.0",
     "enzyme": "^2.2.0",


### PR DESCRIPTION
PropTypes were deprecated in React 15.x and removed in 16.0. If there is still need for proptypes, the [prop-types](https://www.npmjs.com/package/prop-types) package should be used.