### PR TITLE
Fix incorrect AppContainer usage in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,16 @@ import ReactDOM from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
 import App from './containers/App'
 
-ReactDOM.render(
-  <AppContainer>
-    <App/>
-  </AppContainer>,
-  document.getElementById('root'),
-)
+const render = Component => {
+  ReactDOM.render(
+    <AppContainer>
+      <Component />
+    </AppContainer>,
+    document.getElementById('root'),
+  )
+}
+
+render(App)
 
 // Webpack Hot Module Replacement API
 if (module.hot) {


### PR DESCRIPTION
The docs currently use this approach:
```
if (module.hot) {
  module.hot.accept('./containers/App', () => { render(App) });
}
```
But without showing an actual `render` function. This update fixes that discrepancy. 