### PR TITLE
Add support for disabling warnings for unaccepted components

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ render((
 
 You'll also need to `npm install --save-dev redbox-react`.
 
+## Disable warnings
+
+React Hot Loader will by default emit a warning for components not accepted by the Hot Loader. If you want to disable these warnings, you can pass a `warnings` prop with the value `false` to `AppContainer`.
+
+```js
+<AppContainer warnings={false}>
+  ...
+</AppContainer>
+```  
+
 ## Starter Kit
 
 Provided by collaborators:

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -7,6 +7,14 @@ const { Component } = React
 class AppContainer extends Component {
   constructor(props) {
     super(props)
+
+    if (
+      props.warnings === false &&
+      typeof __REACT_HOT_LOADER__ !== 'undefined'
+    ) {
+      __REACT_HOT_LOADER__.warnings = false
+    }
+
     this.state = { error: null }
   }
 
@@ -77,6 +85,7 @@ AppContainer.propTypes = {
     return undefined
   },
   errorReporter: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  warnings: PropTypes.bool,
 }
 
 module.exports = AppContainer

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -8,11 +8,8 @@ class AppContainer extends Component {
   constructor(props) {
     super(props)
 
-    if (
-      props.warnings === false &&
-      typeof __REACT_HOT_LOADER__ !== 'undefined'
-    ) {
-      __REACT_HOT_LOADER__.warnings = false
+    if (typeof __REACT_HOT_LOADER__ !== 'undefined') {
+      __REACT_HOT_LOADER__.warnings = props.warnings
     }
 
     this.state = { error: null }
@@ -86,6 +83,10 @@ AppContainer.propTypes = {
   },
   errorReporter: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   warnings: PropTypes.bool,
+}
+
+AppContainer.defaultProps = {
+  warnings: true,
 }
 
 module.exports = AppContainer

--- a/src/AppContainer.dev.js
+++ b/src/AppContainer.dev.js
@@ -8,7 +8,10 @@ class AppContainer extends Component {
   constructor(props) {
     super(props)
 
-    if (typeof __REACT_HOT_LOADER__ !== 'undefined') {
+    if (
+      props.warnings === false &&
+      typeof __REACT_HOT_LOADER__ !== 'undefined'
+    ) {
       __REACT_HOT_LOADER__.warnings = props.warnings
     }
 
@@ -83,10 +86,6 @@ AppContainer.propTypes = {
   },
   errorReporter: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   warnings: PropTypes.bool,
-}
-
-AppContainer.defaultProps = {
-  warnings: true,
 }
 
 module.exports = AppContainer

--- a/src/patch.dev.js
+++ b/src/patch.dev.js
@@ -119,6 +119,8 @@ const hooks = {
     knownSignatures = {}
     didUpdateProxy = false
   },
+
+  warnings: true,
 }
 
 hooks.reset(typeof WeakMap === 'function')

--- a/src/patch.dev.js
+++ b/src/patch.dev.js
@@ -124,7 +124,7 @@ const hooks = {
 hooks.reset(typeof WeakMap === 'function')
 
 function warnAboutUnnacceptedClass(typeSignature) {
-  if (didUpdateProxy) {
+  if (didUpdateProxy && global.__REACT_HOT_LOADER__.warnings !== false) {
     console.warn(
       'React Hot Loader: this component is not accepted by Hot Loader. \n' +
         'Please check is it extracted as a top level class, a function or a variable. \n' +

--- a/test/AppContainer.dev.test.js
+++ b/test/AppContainer.dev.test.js
@@ -1253,7 +1253,7 @@ function runAllTests(useWeakMap) {
           </AppContainer>,
         )
 
-        expect(RHL.warnings).toBe(undefined)
+        expect(RHL.warnings).toBe(true)
 
         mount(
           <AppContainer warnings={false}>

--- a/test/AppContainer.dev.test.js
+++ b/test/AppContainer.dev.test.js
@@ -1244,6 +1244,27 @@ function runAllTests(useWeakMap) {
         expect(wrapper.text()).toBe('new render + old state + 20')
       })
     })
+
+    describe('container props', () => {
+      it('can disable warnings', () => {
+        mount(
+          <AppContainer>
+            <div>hey</div>
+          </AppContainer>,
+        )
+
+        expect(RHL.warnings).toBe(undefined)
+
+        mount(
+          <AppContainer warnings={false}>
+            <div>hey</div>
+          </AppContainer>,
+        )
+
+        expect(RHL.warnings).toBe(false)
+        delete RHL.warnings
+      })
+    })
   })
 }
 

--- a/test/patch.dev.test.js
+++ b/test/patch.dev.test.js
@@ -99,6 +99,26 @@ function runAllTests(useWeakMap) {
       }
     })
 
+    it('doesn\'t report disabled warnings', () => {
+      const f1 = () => <div>123</div>
+      const dynamic = () => () => <div>123</div>
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        RHL.warnings = false
+
+        RHL.register(f1, 'f1', '/wow/test.js')
+        React.createElement(dynamic())
+        RHL.register(f1, 'f1', '/wow/test.js')
+        React.createElement(dynamic())
+
+        expect(console.warn.mock.calls.length).toBe(0)
+      } finally {
+        spy.mockRestore()
+        delete RHL.warnings
+      }
+    })
+
     it('resolves registered types by their last ID', () => {
       RHL.register(A1, 'a', 'test.js')
       const A = <A1 />.type


### PR DESCRIPTION
Implemented according to instructions in #667. Wasn't sure how to properly re-create the issue in test, but I borrowed the test for the warning and made sure it was being silenced when `__REACT_HOT_LOADER__.warnings` is `false`.

The test for `AppContainer` simply checks that the global variable is being set.

Fixes #667
Fixes #666