### PR TITLE
Remove direct dependency on babel-template

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-loader",
   "dependencies": {
-    "babel-template": "^6.7.0",
     "global": "^4.3.0",
     "react-deep-force-update": "^2.1.1",
     "react-proxy": "^3.0.0-alpha.0",


### PR DESCRIPTION
Use the version provided to the plugin by Babel instead. This helps with
dependency deduping when using Babel 7.