### PR TITLE
Customize scope for arrow functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
   "dependencies": {
     "global": "^4.3.0",
     "react-deep-force-update": "^2.1.1",
-    "react-proxy": "^3.0.0-alpha.0",
+    "react-stand-in": "^1.0.0-alpha-2",
     "redbox-react": "^1.3.6",
-    "source-map": "^0.6.1"
+    "source-map": "^0.6.1",
+    "stacktrace-js": "2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,9 @@
   "dependencies": {
     "global": "^4.3.0",
     "react-deep-force-update": "^2.1.1",
-    "react-stand-in": "^1.0.0-alpha-2",
+    "react-stand-in": "^1.0.2",
     "redbox-react": "^1.3.6",
-    "source-map": "^0.6.1",
-    "stacktrace-js": "2.0.0"
+    "source-map": "^0.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -1,60 +1,5 @@
 const replaced = Symbol('replaced')
 
-const proxyInstance = t => t.memberExpression(t.thisExpression(),t.identifier('__REACT_PROXY_CONTEXT'));
-
-const buildNewClassProperty = (
-  t,
-  classPropertyName,
-  newMethodName,
-  isAsync,
-) => {
-  let returnExpression = t.callExpression(
-    t.memberExpression(proxyInstance(t), newMethodName),
-    [t.spreadElement(t.identifier('params'))],
-  )
-
-  if (isAsync) {
-    returnExpression = t.awaitExpression(returnExpression)
-  }
-
-  const newArrowFunction = t.arrowFunctionExpression(
-    [t.restElement(t.identifier('params'))],
-    returnExpression,
-    isAsync,
-  )
-  return t.classProperty(classPropertyName, newArrowFunction)
-}
-
-const buildNewAssignmentExpression = (
-  t,
-  classPropertyName,
-  newMethodName,
-  isAsync,
-) => {
-  let returnExpression = t.callExpression(
-    t.memberExpression(proxyInstance(t), newMethodName),
-    [t.spreadElement(t.identifier('params'))],
-  )
-
-  if (isAsync) {
-    returnExpression = t.awaitExpression(returnExpression)
-  }
-
-  const newArrowFunction = t.arrowFunctionExpression(
-    [t.restElement(t.identifier('params'))],
-    returnExpression,
-    isAsync,
-  )
-  const left = t.memberExpression(
-    t.thisExpression(),
-    t.identifier(classPropertyName.name),
-  )
-
-  const replacement = t.assignmentExpression('=', left, newArrowFunction)
-  replacement[replaced] = true
-
-  return replacement
-}
 
 const classPropertyOptOutVistor = {
   MetaProperty(path, state) {
@@ -92,6 +37,8 @@ module.exports = function plugin(args) {
   const buildRegistration = template(
     '__REACT_HOT_LOADER__.register(ID, NAME, FILENAME);',
   )
+
+  var evalTemplate = template('this[key]=eval(code);')
 
   // We're making the IIFE we insert at the end of the file an unused variable
   // because it otherwise breaks the output of the babel-node REPL (#359).
@@ -206,115 +153,13 @@ module.exports = function plugin(args) {
       },
       Class(classPath) {
         const classBody = classPath.get('body')
-
-        classBody.get('body').forEach(path => {
-          if (path.isClassProperty()) {
-            const { node } = path
-
-            // don't apply transform to static class properties
-            if (node.static) {
-              return
-            }
-
-            const state = {
-              optOut: false,
-            }
-
-            path.traverse(classPropertyOptOutVistor, state)
-
-            if (state.optOut) {
-              return
-            }
-
-            // class property node value is nullable
-            if (node.value && node.value.type === 'ArrowFunctionExpression') {
-              const isAsync = node.value.async
-
-              // TODO:
-              // Remove this check when babel issue is resolved: https://github.com/babel/babel/issues/5078
-              // RHL Issue: https://github.com/gaearon/react-hot-loader/issues/391
-              // This code makes async arrow functions not reloadable,
-              // but doesn't break code any more when using 'this' inside AAF
-              if (isAsync) {
-                return
-              }
-
-              const { params } = node.value
-              const newIdentifier = t.identifier(
-                `__${node.key.name}__REACT_HOT_LOADER__`,
-              )
-
-              // arrow function body can either be a block statement or a returned expression
-              const newMethodBody =
-                node.value.body.type === 'BlockStatement'
-                  ? node.value.body
-                  : t.blockStatement([t.returnStatement(node.value.body)])
-
-              // create a new method on the class that the original class property function
-              // calls, since the method is able to be replaced by RHL
-              const newMethod = t.classMethod(
-                'method',
-                newIdentifier,
-                params,
-                newMethodBody,
-              )
-              newMethod.async = isAsync
-              path.insertAfter(newMethod)
-
-              // replace the original class property function with a function that calls
-              // the new class method created above
-              path.replaceWith(
-                buildNewClassProperty(t, node.key, newIdentifier, isAsync),
-              )
-            }
-          } else if (!path.node[replaced] && path.node.kind === 'constructor') {
-            path.traverse({
-              AssignmentExpression(exp) {
-                if (
-                  !exp.node[replaced] &&
-                  exp.node.left.type === 'MemberExpression' &&
-                  exp.node.left.object.type === 'ThisExpression' &&
-                  exp.node.right.type === 'ArrowFunctionExpression'
-                ) {
-                  const key = exp.node.left.property
-                  const node = exp.node.right
-
-                  const isAsync = node.async
-                  const { params } = node
-                  const newIdentifier = t.identifier(
-                    `__${key.name}__REACT_HOT_LOADER__`,
-                  )
-
-                  // arrow function body can either be a block statement or a returned expression
-                  const newMethodBody =
-                    node.body.type === 'BlockStatement'
-                      ? node.body
-                      : t.blockStatement([t.returnStatement(node.body)])
-
-                  const newMethod = t.classMethod(
-                    'method',
-                    newIdentifier,
-                    params,
-                    newMethodBody,
-                  )
-                  newMethod.async = isAsync
-                  newMethod[replaced] = true
-                  path.insertAfter(newMethod)
-
-                  // replace assignment exp
-                  exp.replaceWith(
-                    buildNewAssignmentExpression(
-                      t,
-                      key,
-                      newIdentifier,
-                      isAsync,
-                    ),
-                  )
-                }
-              },
-            })
-          }
-        })
+        var newMethod = t.classMethod(
+          'method',
+          t.identifier('__facade__regenerateByEval'),
+          [t.identifier('key'), t.identifier('code')],
+          t.blockStatement([evalTemplate()])
+        )
+        classBody.pushContainer('body',newMethod)
       },
     },
   }

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -1,5 +1,7 @@
 const replaced = Symbol('replaced')
 
+const proxyInstance = t => t.memberExpression(t.thisExpression(),t.identifier('__REACT_PROXY_CONTEXT'));
+
 const buildNewClassProperty = (
   t,
   classPropertyName,
@@ -7,7 +9,7 @@ const buildNewClassProperty = (
   isAsync,
 ) => {
   let returnExpression = t.callExpression(
-    t.memberExpression(t.thisExpression(), newMethodName),
+    t.memberExpression(proxyInstance(t), newMethodName),
     [t.spreadElement(t.identifier('params'))],
   )
 
@@ -30,7 +32,7 @@ const buildNewAssignmentExpression = (
   isAsync,
 ) => {
   let returnExpression = t.callExpression(
-    t.memberExpression(t.thisExpression(), newMethodName),
+    t.memberExpression(proxyInstance(t), newMethodName),
     [t.spreadElement(t.identifier('params'))],
   )
 

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -40,6 +40,8 @@ module.exports = function plugin(args) {
 
   var evalTemplate = template('this[key]=eval(code);')
 
+  var rewireSuperTemplate = template('ID=superClass;');
+
   // We're making the IIFE we insert at the end of the file an unused variable
   // because it otherwise breaks the output of the babel-node REPL (#359).
   const buildTagger = template(`
@@ -153,6 +155,7 @@ module.exports = function plugin(args) {
       },
       Class(classPath) {
         const classBody = classPath.get('body')
+
         var newMethod = t.classMethod(
           'method',
           t.identifier('__facade__regenerateByEval'),
@@ -160,6 +163,13 @@ module.exports = function plugin(args) {
           t.blockStatement([evalTemplate()])
         )
         classBody.pushContainer('body',newMethod)
+
+        var newMethod = t.classMethod(
+          'method',
+          t.identifier('__facade__rewireSuper'),
+          [t.identifier('superClass')],
+          t.blockStatement([rewireSuperTemplate({ ID: t.identifier(classPath.node.id.name) })]));
+        classBody.pushContainer('body', newMethod);
       },
     },
   }

--- a/test/__snapshots__/babel.test.js.snap
+++ b/test/__snapshots__/babel.test.js.snap
@@ -9,23 +9,36 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
+    var _arguments = arguments;
 
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
+    this.bar = function (a, b) {
+      _arguments;
 
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+      return a(b);
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
-      arguments;
-
-      return a(b);
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -54,21 +67,32 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.onClick = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__onClick__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+    this.onClick = function (e) {
+      return e.target.value;
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__onClick__REACT_HOT_LOADER__\\",
-    value: function __onClick__REACT_HOT_LOADER__(e) {
-      return e.target.value;
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -104,16 +128,13 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-        var _REACT_PROXY_CONTEXT;
-
-        var _args = arguments;
+      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(a, b) {
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
                 _context.next = 2;
-                return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, _args);
+                return b(a);
 
               case 2:
                 return _context.abrupt(\\"return\\", _context.sent);
@@ -126,40 +147,32 @@ var Foo = function () {
         }, _callee, _this);
       }));
 
-      return function NAME() {
+      return function (_x, _x2) {
         return _ref.apply(this, arguments);
       };
     }();
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function () {
-      var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(a, b) {
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                _context2.next = 2;
-                return b(a);
-
-              case 2:
-                return _context2.abrupt(\\"return\\", _context2.sent);
-
-              case 3:
-              case \\"end\\":
-                return _context2.stop();
-            }
-          }
-        }, _callee2, this);
-      }));
-
-      function __bar__REACT_HOT_LOADER__(_x, _x2) {
-        return _ref2.apply(this, arguments);
-      }
-
-      return __bar__REACT_HOT_LOADER__;
-    }()
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
   }]);
 
   return Foo;
@@ -194,16 +207,13 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-        var _REACT_PROXY_CONTEXT;
-
-        var _args = arguments;
+      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(a, b) {
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
                 _context.next = 2;
-                return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, _args);
+                return a(b);
 
               case 2:
                 return _context.abrupt(\\"return\\", _context.sent);
@@ -216,40 +226,32 @@ var Foo = function () {
         }, _callee, _this);
       }));
 
-      return function NAME() {
+      return function (_x, _x2) {
         return _ref.apply(this, arguments);
       };
     }();
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function () {
-      var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(a, b) {
-        return regeneratorRuntime.wrap(function _callee2$(_context2) {
-          while (1) {
-            switch (_context2.prev = _context2.next) {
-              case 0:
-                _context2.next = 2;
-                return a(b);
-
-              case 2:
-                return _context2.abrupt(\\"return\\", _context2.sent);
-
-              case 3:
-              case \\"end\\":
-                return _context2.stop();
-            }
-          }
-        }, _callee2, this);
-      }));
-
-      function __bar__REACT_HOT_LOADER__(_x, _x2) {
-        return _ref2.apply(this, arguments);
-      }
-
-      return __bar__REACT_HOT_LOADER__;
-    }()
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
   }]);
 
   return Foo;
@@ -277,21 +279,32 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+    this.bar = function (a, b) {
+      return a(b);
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
-      return a(b);
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -320,23 +333,34 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
+      var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : \\"foo\\";
 
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+      return a + \\"bar\\";
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__() {
-      var a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : \\"foo\\";
-
-      return a + \\"bar\\";
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -365,24 +389,35 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
-    };
-  }
-
-  _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(_ref, _ref2) {
+    this.bar = function (_ref, _ref2) {
       var a = _ref.a;
       var b = _ref2.b;
 
       return \\"\\" + a + b;
+    };
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -411,21 +446,32 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.onClick = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__onClick__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+    this.onClick = function (e) {
+      return e.target.value;
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__onClick__REACT_HOT_LOADER__\\",
-    value: function __onClick__REACT_HOT_LOADER__(e) {
-      return e.target.value;
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -454,27 +500,38 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
+    var _arguments = arguments;
 
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
-    };
-  }
-
-  _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
-      var _arguments = arguments;
-
+    this.bar = function (a, b) {
       (function () {
         _arguments;
       });
 
       return a(b);
+    };
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -503,25 +560,36 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
-    };
-  }
-
-  _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
+    this.bar = function (a, b) {
       (function () {
         new.target;
       });
 
       return a(b);
+    };
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -550,23 +618,34 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
+    this.bar = function (a, b) {
+      new.target;
 
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+      return a(b);
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
-      new.target;
-
-      return a(b);
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -589,13 +668,41 @@ var _temp = function () {
 exports[`copies arrow function body block onto hidden class methods not a function.js 1`] = `
 "\\"use strict\\";
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-var Foo = function Foo() {
-  _classCallCheck(this, Foo);
+var Foo = function () {
+  function Foo() {
+    _classCallCheck(this, Foo);
 
-  this.bar = 2;
-};
+    this.bar = 2;
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }]);
+
+  return Foo;
+}();
 
 ;
 
@@ -613,15 +720,43 @@ var _temp = function () {
 exports[`copies arrow function body block onto hidden class methods not an arrow function.js 1`] = `
 "\\"use strict\\";
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-var Foo = function Foo() {
-  _classCallCheck(this, Foo);
+var Foo = function () {
+  function Foo() {
+    _classCallCheck(this, Foo);
 
-  this.bar = function (a, b) {
-    return a(b);
-  };
-};
+    this.bar = function (a, b) {
+      return a(b);
+    };
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }]);
+
+  return Foo;
+}();
 
 ;
 
@@ -645,26 +780,37 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 var Foo = function () {
   function Foo() {
-    var _this = this;
-
     _classCallCheck(this, Foo);
 
-    this.bar = function () {
-      var _REACT_PROXY_CONTEXT;
-
-      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
+    this.bar = function (a, b) {
+      return a(b);
     };
   }
 
   _createClass(Foo, [{
-    key: \\"__bar__REACT_HOT_LOADER__\\",
-    value: function __bar__REACT_HOT_LOADER__(a, b) {
-      return a(b);
-    }
-  }, {
     key: \\"bar\\",
     value: function bar() {
       return 2;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
     }
   }]);
 
@@ -687,11 +833,39 @@ var _temp = function () {
 exports[`copies arrow function body block onto hidden class methods static property.js 1`] = `
 "\\"use strict\\";
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-var Foo = function Foo() {
-  _classCallCheck(this, Foo);
-};
+var Foo = function () {
+  function Foo() {
+    _classCallCheck(this, Foo);
+  }
+
+  _createClass(Foo, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Foo = superClass;
+    }
+  }]);
+
+  return Foo;
+}();
 
 Foo.bar = function (a, b) {
   return a(b);
@@ -732,9 +906,35 @@ var A = 42;
 function B() {
   function R() {}
 
-  var S = function S() {
-    _classCallCheck(this, S);
-  };
+  var S = function () {
+    function S() {
+      _classCallCheck(this, S);
+    }
+
+    _createClass(S, [{
+      key: \\"__facade__regenerateByEval\\",
+      value: function __facade__regenerateByEval(key, code) {
+        this[key] = eval(code);
+      }
+    }, {
+      key: \\"__facade__rewireSuper\\",
+      value: function __facade__rewireSuper(superClass) {
+        S = superClass;
+      }
+    }, {
+      key: \\"__facade__regenerateByEval\\",
+      value: function __facade__regenerateByEval(key, code) {
+        this[key] = eval(code);
+      }
+    }, {
+      key: \\"__facade__rewireSuper\\",
+      value: function __facade__rewireSuper(superClass) {
+        S = superClass;
+      }
+    }]);
+
+    return S;
+  }();
 
   var T = 42;
 }
@@ -748,19 +948,81 @@ var C = exports.C = function () {
     key: \\"U\\",
     value: function U() {
       function V() {
-        var W = function W() {
-          _classCallCheck(this, W);
-        };
+        var W = function () {
+          function W() {
+            _classCallCheck(this, W);
+          }
+
+          _createClass(W, [{
+            key: \\"__facade__regenerateByEval\\",
+            value: function __facade__regenerateByEval(key, code) {
+              this[key] = eval(code);
+            }
+          }, {
+            key: \\"__facade__rewireSuper\\",
+            value: function __facade__rewireSuper(superClass) {
+              W = superClass;
+            }
+          }, {
+            key: \\"__facade__regenerateByEval\\",
+            value: function __facade__regenerateByEval(key, code) {
+              this[key] = eval(code);
+            }
+          }, {
+            key: \\"__facade__rewireSuper\\",
+            value: function __facade__rewireSuper(superClass) {
+              W = superClass;
+            }
+          }]);
+
+          return W;
+        }();
       }
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      C = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      C = superClass;
     }
   }]);
 
   return C;
 }();
 
-var D = function X() {
-  _classCallCheck(this, X);
-};
+var D = function () {
+  function X() {
+    _classCallCheck(this, X);
+  }
+
+  _createClass(X, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      X = superClass;
+    }
+  }]);
+
+  return X;
+}();
 var E = D;
 var Y = require(\\"left-pad\\");
 
@@ -802,11 +1064,39 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-var Counter = function Counter() {
-  _classCallCheck(this, Counter);
-};
+var Counter = function () {
+  function Counter() {
+    _classCallCheck(this, Counter);
+  }
+
+  _createClass(Counter, [{
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Counter = superClass;
+    }
+  }, {
+    key: \\"__facade__regenerateByEval\\",
+    value: function __facade__regenerateByEval(key, code) {
+      this[key] = eval(code);
+    }
+  }, {
+    key: \\"__facade__rewireSuper\\",
+    value: function __facade__rewireSuper(superClass) {
+      Counter = superClass;
+    }
+  }]);
+
+  return Counter;
+}();
 
 var _default = function _default() {
   return React.createElement(

--- a/test/__snapshots__/babel.test.js.snap
+++ b/test/__snapshots__/babel.test.js.snap
@@ -14,7 +14,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -57,7 +59,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.onClick = function () {
-      return _this.__onClick__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__onClick__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -101,13 +105,15 @@ var Foo = function () {
 
     this.bar = function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+        var _REACT_PROXY_CONTEXT;
+
         var _args = arguments;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
                 _context.next = 2;
-                return _this.__bar__REACT_HOT_LOADER__.apply(_this, _args);
+                return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, _args);
 
               case 2:
                 return _context.abrupt(\\"return\\", _context.sent);
@@ -189,13 +195,15 @@ var Foo = function () {
 
     this.bar = function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+        var _REACT_PROXY_CONTEXT;
+
         var _args = arguments;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
                 _context.next = 2;
-                return _this.__bar__REACT_HOT_LOADER__.apply(_this, _args);
+                return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, _args);
 
               case 2:
                 return _context.abrupt(\\"return\\", _context.sent);
@@ -274,7 +282,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -315,7 +325,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -358,7 +370,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -402,7 +416,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.onClick = function () {
-      return _this.__onClick__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__onClick__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -443,7 +459,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -490,7 +508,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -535,7 +555,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 
@@ -628,7 +650,9 @@ var Foo = function () {
     _classCallCheck(this, Foo);
 
     this.bar = function () {
-      return _this.__bar__REACT_HOT_LOADER__.apply(_this, arguments);
+      var _REACT_PROXY_CONTEXT;
+
+      return (_REACT_PROXY_CONTEXT = _this.__REACT_PROXY_CONTEXT).__bar__REACT_HOT_LOADER__.apply(_REACT_PROXY_CONTEXT, arguments);
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,12 +1417,6 @@ error-stack-parser@^1.3.6:
   dependencies:
     stackframe "^0.3.1"
 
-error-stack-parser@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.1.tgz#a3202b8fb03114aa9b40a0e3669e48b2b65a010a"
-  dependencies:
-    stackframe "^1.0.3"
-
 es-abstract@^1.5.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
@@ -3296,15 +3290,9 @@ react-dom@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-proxy@^3.0.0-alpha.0:
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
-  dependencies:
-    lodash "^4.6.1"
-
-react-stand-in@false1.0.0-alpha-2:
-  version "1.0.0-alpha-2"
-  resolved "https://registry.yarnpkg.com/react-stand-in/-/react-stand-in-1.0.0-alpha-2.tgz#319c2bb502c143864796d979ad6334b7e6903490"
+react-stand-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-stand-in/-/react-stand-in-1.0.2.tgz#c73f2659baa436d9533341d54100b03e864256f9"
   dependencies:
     lodash "^4.6.1"
 
@@ -3695,34 +3683,9 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-stack-generator@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.2.tgz#3c13d952a596ab9318fec0669d0a1df8b87176c7"
-  dependencies:
-    stackframe "^1.0.4"
-
 stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
-
-stackframe@^1.0.3, stackframe@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
-
-stacktrace-gps@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
-  dependencies:
-    source-map "0.5.6"
-    stackframe "^1.0.4"
-
-stacktrace-js@false2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
-  dependencies:
-    error-stack-parser "^2.0.1"
-    stack-generator "^2.0.1"
-    stacktrace-gps "^3.0.1"
 
 string-length@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,6 +1417,12 @@ error-stack-parser@^1.3.6:
   dependencies:
     stackframe "^0.3.1"
 
+error-stack-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.1.tgz#a3202b8fb03114aa9b40a0e3669e48b2b65a010a"
+  dependencies:
+    stackframe "^1.0.3"
+
 es-abstract@^1.5.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
@@ -3296,6 +3302,12 @@ react-proxy@^3.0.0-alpha.0:
   dependencies:
     lodash "^4.6.1"
 
+react-stand-in@false1.0.0-alpha-2:
+  version "1.0.0-alpha-2"
+  resolved "https://registry.yarnpkg.com/react-stand-in/-/react-stand-in-1.0.0-alpha-2.tgz#319c2bb502c143864796d979ad6334b7e6903490"
+  dependencies:
+    lodash "^4.6.1"
+
 react-test-renderer@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
@@ -3683,9 +3695,34 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-generator@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.2.tgz#3c13d952a596ab9318fec0669d0a1df8b87176c7"
+  dependencies:
+    stackframe "^1.0.4"
+
 stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+
+stackframe@^1.0.3, stackframe@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+
+stacktrace-gps@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.0.4"
+
+stacktrace-js@false2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
+  dependencies:
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes https://github.com/gaearon/react-hot-loader/issues/391 and (already closed) https://github.com/gaearon/react-hot-loader/issues/242

@neoziro, this is the same idea, that I mentioned in your PR.

Problem – react-proxy instances `ES5 classes` with correct `this`, but cannot repeat the trick with ES6 classes, as result new Components will be created with their own contexts.
In other word - `this` in arrow function will target the `real` component, but one can use only the proxied one.

Solution - store pointer to the proxy context inside instance, and use it.

This PR does include just a change of babel plugin, to work normally it requires changes in react-proxy, but version 3, used by RHL is not public :(


The one, who wants repeat the trick - just copy-paste code to the createProxyClass.js
```js
function linkInstance(instance, context){
  try {
    instance.__REACT_PROXY_CONTEXT = context.__REACT_PROXY_CONTEXT = context;
  } catch (err) {};
  return instance;
}

function proxyClass(InitialComponent) {
  // Prevent double wrapping.
  // Given a proxy class, return the existing proxy managing it.
  var existingProxy = findProxy(InitialComponent);
  if (existingProxy) {
    return existingProxy;
  }

  let CurrentComponent;
  let ProxyComponent;
  let savedDescriptors = {};

  function instantiate(factory, context, params) {
    const component = factory();

    try {
      return linkInstance(component.apply(context, params), context); // <----
    } catch (err) {
      // Native ES6 class instantiation
      const instance = new component(...params);

      Object.keys(instance).forEach(key => {
        if (RESERVED_STATICS.indexOf(key) > -1) {
          return;
        }
        context[key] = instance[key];
      });

      linkInstance(instance, context);  /// <-- not returning anything
    }
  }
```

Tested both in es5 and es6 environments – all green.