### PR TITLE
Add note about setting output.publicPath property

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ module.exports = {
 }
 ```
 
+> Note: Make sure to set the `output.publicPath` property to `"/"` as well. Otherwise hot reloading won't work as expected for nested routes.
+
 4. Wrap your application into `<AppContainer>`, all children of `<AppContainer>` will be reloaded when a change occurs:
 
 ```js


### PR DESCRIPTION
This PR adds a note about the importance of having the
`output.publicPath` property set to the correct value. Without it,
hot reloading will not work for nested routes like `/some/path`.

I'm up for a discussion about the wording or placement of this note - but I strongly feel that this should be mentioned in the docs. It has cost me a few hours of debugging through the last couple of months (I always forget how to fix this error when it shows up), and it would have been fairly simple to fix if somebody just told me it had to be set :) 