### PR TITLE
Fix Babel 7 breaking issue: Specify placeholderPattern in template call

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -86,9 +86,13 @@ module.exports = function plugin(args) {
     )
   }
   const { types: t, template } = args
+  
+  const templateOptions = {
+    placeholderPattern: /^([A-Z0-9]+)([A-Z0-9_]+)$/
+  }  
 
   const buildRegistration = template(
-    '__REACT_HOT_LOADER__.register(ID, NAME, FILENAME);',
+    '__REACT_HOT_LOADER__.register(ID, NAME, FILENAME);', templateOptions,
   )
 
   // We're making the IIFE we insert at the end of the file an unused variable
@@ -101,7 +105,7 @@ module.exports = function plugin(args) {
 
     REGISTRATIONS
   })();
-  `)
+  `, templateOptions)
 
   // No-op in production.
   if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
`babel-template` assumes that any string that is all uppercase is a placeholder. 

In Babel 6, there are no problems if you don't provide a value for the placeholder in the call to the created template function. However, in Babel 7 `@babel/template` has new options, one of which is `placeholderPattern`. The default value is ` /^[_$A-Z0-9]+$/` -- so that means that within `react-hot-loader/src/babel/index.js`, the call to create a template function is trying to take `__REACT_HOT_LOADER__` as a placeholder value, when it is not and should be used as a literal value.

Currently in Babel 7, `react-hot-loader` will produce the following error, stemming from `@babel/template`:
`Module build failed: Error: No substitution given for "__REACT_HOT_LOADER__"`

The simple solution is to provide the options parameter to the `template` call, with `placeholderPattern` set to `/^([A-Z0-9]+)([A-Z0-9_]+)$/` so that only placeholders that __do not__ start with an underscore are evaluated. __The good news is that this does not at all interfere with Babel 6:__ I confirmed that passing the `placeholderPattern` to the Babel 6 variation of `babel-template` just passes through with no error or effect.

I know this may be considered a bit premature since Babel 7 is still in beta, but it's such a small change and it doesn't seem too likely that the options configuration in `@babel/template` will change.

I can confirm that when making this change locally, react-hot-loader no longer throws an error when bundled using Babel 7.