### PR TITLE
React-Hot-Loader Tools

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,23 @@
 {
   "presets": [
-    ["env",
-    {
-      "targets": {
-        "browsers": [
-          "last 2 chrome versions",
-          "last 2 firefox versions",
-          "last 2 safari versions",
-          "last 2 edge versions"
-        ]
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "last 2 chrome versions",
+            "last 2 firefox versions",
+            "last 2 safari versions",
+            "last 2 edge versions"
+          ]
+        }
       }
-    }
-  ], "react"],
-  "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+    ],
+    "react"
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    "dynamic-import-node"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-core": "^6.7.6",
     "babel-eslint": "^8.0.1",
     "babel-jest": "^21.2.0",
+    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
@@ -53,9 +54,12 @@
       "node_modules",
       "<rootDir>"
     ],
-    "setupFiles": ["<rootDir>/testConfig/setupTests.js"],
+    "setupFiles": [
+      "<rootDir>/testConfig/setupTests.js"
+    ],
     "transform": {
       "^.+\\.js$": "<rootDir>/testConfig/babel.js"
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/react-hot-loader/package.json
+++ b/packages/react-hot-loader/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
+    "hoist-non-react-statics": "^2.3.1",
     "react-deep-force-update": "^4.0.0-beta.1",
     "react-stand-in": "^4.0.0-beta.1",
     "redbox-react": "^1.3.6",

--- a/packages/react-hot-loader/src/index.dev.js
+++ b/packages/react-hot-loader/src/index.dev.js
@@ -1,6 +1,7 @@
 import AppContainer from './AppContainer'
+import { hotExported, compareComponents } from './utils.dev'
 
-export { AppContainer }
+export { AppContainer, hotExported, compareComponents }
 
 export default function warnAboutIncorrectUsage(arg) {
   if (this && this.callback) {

--- a/packages/react-hot-loader/src/index.prod.js
+++ b/packages/react-hot-loader/src/index.prod.js
@@ -1,1 +1,4 @@
 export { default as AppContainer } from './AppContainer'
+
+export const compareComponents = (a, b) => a === b
+export const hotExported = (module, Component) => Component

--- a/packages/react-hot-loader/src/utils.dev.js
+++ b/packages/react-hot-loader/src/utils.dev.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react'
+import hoistNonReactStatic from 'hoist-non-react-statics'
+import AppContainer from './AppContainer.dev'
+
+const getDisplayName = WrappedComponent =>
+  WrappedComponent.displayName || WrappedComponent.name || 'Component'
+
+const copyReactProp = (source, target) => {
+  hoistNonReactStatic(target, source)
+  target.displayName = `HotExported${getDisplayName(source)}`
+  target.WrappedComponent = source
+
+  target.propTypes = source.contextTypes
+  target.childContextTypes = source.childContextTypes
+  target.contextTypes = source.contextTypes
+}
+
+const makeHotExport = (sourceModule, getInstances) => {
+  const updateInstances = () => {
+    getInstances().forEach(inst => inst.forceUpdate())
+  }
+
+  const thenUpdateInstances = () => Promise.resolve(true).then(updateInstances)
+
+  if (sourceModule.hot) {
+    sourceModule.hot.accept(() => {
+      // Mark as self-accepted for Webpack
+      // Update instances for parsel
+      thenUpdateInstances()
+    })
+
+    // webpack way
+    if (sourceModule.hot.addStatusHandler) {
+      if (sourceModule.hot.status() === 'idle') {
+        sourceModule.hot.addStatusHandler(status => {
+          if (status === 'apply') {
+            thenUpdateInstances()
+          }
+        })
+      }
+    }
+  }
+}
+
+export const hotExported = (sourceModule, WrappedComponent, props = {}) => {
+  let instances = []
+
+  class ExportedComponent extends Component {
+    componentWillMount() {
+      instances.push(this)
+    }
+
+    componentWillUnmount() {
+      instances = instances.filter(a => a !== this)
+    }
+
+    render() {
+      return (
+        <AppContainer {...props}>
+          <WrappedComponent {...this.props} />
+        </AppContainer>
+      )
+    }
+  }
+
+  copyReactProp(WrappedComponent, ExportedComponent)
+
+  makeHotExport(sourceModule, () => instances)
+
+  // TODO: Ensure that all exports from this file are react components.
+
+  return ExportedComponent
+}
+
+// TODO: refactor for Reconcile branch
+export const compareComponents = (a, b) => a === b


### PR DESCRIPTION
Introducing 2 new named exports:
1. `compareComponents`(typeA, typeB) , as was requested in #304. As long getProxy was extracted from patch in reconciler branch - here it actually does nothing.
2. `hotExported`(module, Component), as discussed 2 weeks ago in #707. Also closes #700 

There is no unit tests yet, as I am not ready to introduce karma to test webpack/parsel. But manual testing reports - everything is ok.

Now one can just "mark" export to be _hot exported_, and it will be. As result it will be close to impossible to got a wrong configuration, and it also seamlessly works with any "async-loader"

TODO:
 1. Test with parcel-bundler (it does include [information about RHL](https://parceljs.org/hmr.html), but without example)
 2. Add checks for module exports. As long file is self-accepted, it should not export anything RHL can not handle.
 3. Create `@hotExported` decorator. Not sure hot(in which standard) I can do it.