### PR TITLE
Fix componentWillUpdate error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 coverage
 .DS_Store
+.idea

--- a/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
+++ b/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
@@ -16,6 +16,8 @@ const areNamesEqual = (a, b) =>
   a === b || (UNDEFINED_NAMES[a] && UNDEFINED_NAMES[b])
 const isReactClass = fn => fn && !!fn.render
 const isFunctional = fn => typeof fn === 'function'
+const isConnectedComponent = fn =>
+  typeof fn.version !== 'undefined' && fn.setWrappedInstance
 const isArray = fn => Array.isArray(fn)
 const asArray = a => (isArray(a) ? a : [a])
 const getTypeOf = type => {
@@ -95,7 +97,7 @@ const render = component => {
     return []
   }
   if (isReactClass(component)) {
-    if (component.componentWillUpdate) {
+    if (component.componentWillUpdate && isConnectedComponent(component)) {
       // force-refresh component (bypass redux renderedComponent)
       component.componentWillUpdate()
     }


### PR DESCRIPTION
Hi, 
I have tried to move to v4 version and faced with an error(`nextProps/nextState is undefined`), when componentWillUpdate is [called](https://github.com/gaearon/react-hot-loader/blob/next/packages/react-hot-loader/src/reconciler/hotReplacementRender.js#L98) on the non react-redux connected component.

As a solution: I suggest to ensure that the component is a connected component and after that call the componentWillUpdate.

As a second solution: pass nextProps and nextState to the componentWillUpdate, but I'm not sure that it is possible.
