### PR TITLE
Detect when hot for used for a render root. 

### DIFF
--- a/packages/react-hot-loader/src/babel.js
+++ b/packages/react-hot-loader/src/babel.js
@@ -23,7 +23,13 @@ module.exports = function plugin(args) {
     'reactHotLoader.register(ID, NAME, FILENAME);',
     templateOptions,
   )
-  const headerTemplate = template("require('react-hot-loader/patch');")
+  const headerTemplate = template(
+    `(function(){ 
+       var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+       moduleEntry && moduleEntry.enter(module);
+     })()`,
+    templateOptions,
+  )
   const evalTemplate = template('this[key]=eval(code);', templateOptions)
 
   // We're making the IIFE we insert at the end of the file an unused variable
@@ -31,13 +37,15 @@ module.exports = function plugin(args) {
   const buildTagger = template(
     `
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var { default: reactHotLoader, moduleEntry } = require('react-hot-loader/patch');  
 
   if (!reactHotLoader) {
     return;
   }
-
+  
   REGISTRATIONS
+  
+  moduleEntry.leave(module);
 })();
   `,
     templateOptions,

--- a/packages/react-hot-loader/src/babel.js
+++ b/packages/react-hot-loader/src/babel.js
@@ -24,10 +24,10 @@ module.exports = function plugin(args) {
     templateOptions,
   )
   const headerTemplate = template(
-    `(function(){ 
+    `(function () {
        var moduleEntry = require('react-hot-loader/patch').moduleEntry;
        moduleEntry && moduleEntry.enter(module);
-     })()`,
+     }())`,
     templateOptions,
   )
   const evalTemplate = template('this[key]=eval(code);', templateOptions)
@@ -37,16 +37,17 @@ module.exports = function plugin(args) {
   const buildTagger = template(
     `
 (function () {
-  var { default: reactHotLoader, moduleEntry } = require('react-hot-loader/patch');  
+  var reactHotLoader = require('react-hot-loader/patch').default;
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
   }
-  
+
   REGISTRATIONS
-  
+
   moduleEntry.leave(module);
-})();
+}());
   `,
     templateOptions,
   )

--- a/packages/react-hot-loader/src/hot.dev.js
+++ b/packages/react-hot-loader/src/hot.dev.js
@@ -3,6 +3,7 @@ import hoistNonReactStatic from 'hoist-non-react-statics'
 import { getComponentDisplayName } from './internal/reactUtils'
 import AppContainer from './AppContainer.dev'
 import reactHotLoader from './reactHotLoader'
+import { isModuleOpened } from './hotModule'
 
 const createHoc = (SourceComponent, TargetComponent) => {
   hoistNonReactStatic(TargetComponent, SourceComponent)
@@ -55,6 +56,17 @@ const hot = sourceModule => {
         }
 
         componentWillUnmount() {
+          if (isModuleOpened(sourceModule)) {
+            const componentName = getComponentDisplayName(WrappedComponent)
+            console.error(
+              `React-hot-loader: Detected AppContainer unmount on module '${
+                sourceModule.id
+              }' update.
+              Did you use {hot} on a ${componentName} in the same file with 'render' from 'react-dom'?
+              {hot} shall only be used to mark _exports_, better - default export only. 
+              Never use it on imports or arbitrary variables.`,
+            )
+          }
           instances = instances.filter(a => a !== this)
         }
 

--- a/packages/react-hot-loader/src/hot.dev.js
+++ b/packages/react-hot-loader/src/hot.dev.js
@@ -4,6 +4,7 @@ import { getComponentDisplayName } from './internal/reactUtils'
 import AppContainer from './AppContainer.dev'
 import reactHotLoader from './reactHotLoader'
 import { isModuleOpened } from './hotModule'
+import logger from './logger'
 
 const createHoc = (SourceComponent, TargetComponent) => {
   hoistNonReactStatic(TargetComponent, SourceComponent)
@@ -58,13 +59,13 @@ const hot = sourceModule => {
         componentWillUnmount() {
           if (isModuleOpened(sourceModule)) {
             const componentName = getComponentDisplayName(WrappedComponent)
-            console.error(
+            logger.error(
               `React-hot-loader: Detected AppContainer unmount on module '${
                 sourceModule.id
-              }' update.
-              Did you use {hot} on a ${componentName} in the same file with 'render' from 'react-dom'?
-              {hot} shall only be used to mark _exports_, better - default export only. 
-              Never use it on imports or arbitrary variables.`,
+              }' update.\n` +
+                `Did you use "hot(${componentName})" and "ReactDOM.render()" in the same file?\n` +
+                `"hot(${componentName})" shall only be used as export.\n` +
+                `Please refer to "Getting Started" (https://github.com/gaearon/react-hot-loader/).`,
             )
           }
           instances = instances.filter(a => a !== this)

--- a/packages/react-hot-loader/src/hotModule.js
+++ b/packages/react-hot-loader/src/hotModule.js
@@ -1,0 +1,16 @@
+const moduleOpened = {}
+
+const moduleEntry = {
+  enter(sourceModule) {
+    const moduleId = sourceModule.id
+    moduleOpened[moduleId] = true
+  },
+
+  leave(sourceModule) {
+    delete moduleOpened[sourceModule.id]
+  },
+}
+
+export const isModuleOpened = module => !!moduleOpened[module.id]
+
+export default moduleEntry

--- a/packages/react-hot-loader/src/patch.dev.js
+++ b/packages/react-hot-loader/src/patch.dev.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import reactHotLoader from './reactHotLoader'
+import moduleEntry from './hotModule'
 
 reactHotLoader.patch(React)
+
+export { moduleEntry }
 
 export default reactHotLoader

--- a/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
+++ b/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
@@ -181,7 +181,7 @@ const hotReplacementRender = (instance, stack) => {
     }
 
     // text node
-    if (typeof child !== 'object' || !stackChild.instance) {
+    if (typeof child !== 'object' || !stackChild || !stackChild.instance) {
       return
     }
 

--- a/packages/react-hot-loader/test/__snapshots__/babel.test.js.snap
+++ b/packages/react-hot-loader/test/__snapshots__/babel.test.js.snap
@@ -7,7 +7,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -35,13 +39,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -54,7 +62,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -78,13 +90,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -99,7 +115,11 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -146,13 +166,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -167,7 +191,11 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -214,13 +242,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -233,7 +265,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -257,13 +293,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -276,7 +316,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -302,13 +346,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -321,7 +369,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -348,13 +400,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -367,7 +423,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -391,13 +451,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -410,7 +474,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -440,13 +508,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -459,7 +531,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -487,13 +563,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -506,7 +586,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -532,13 +616,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -551,7 +639,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -573,13 +665,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -592,7 +688,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -616,13 +716,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -635,7 +739,11 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function () {
   function Foo() {
@@ -664,13 +772,17 @@ var Foo = function () {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -681,7 +793,11 @@ exports[`Targetting "es2015" copies arrow function body block onto hidden class 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Foo = function Foo() {
   _classCallCheck(this, Foo);
@@ -694,13 +810,17 @@ Foo.bar = function (a, b) {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -724,7 +844,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var A = 42;
 function B() {
@@ -778,7 +902,10 @@ exports.default = _default;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -790,6 +917,7 @@ exports.default = _default;
   reactHotLoader.register(D, \\"D\\", __FILENAME__);
   reactHotLoader.register(E, \\"E\\", __FILENAME__);
   reactHotLoader.register(_default, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -804,7 +932,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var Counter = function Counter() {
   _classCallCheck(this, Counter);
@@ -822,7 +954,10 @@ exports.default = _default;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -830,6 +965,7 @@ exports.default = _default;
 
   reactHotLoader.register(Counter, \\"Counter\\", __FILENAME__);
   reactHotLoader.register(_default, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -843,7 +979,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
 });
 exports.spread = spread;
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 function spread() {
   for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
@@ -855,13 +995,17 @@ function spread() {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(spread, \\"spread\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -874,7 +1018,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 var _default = 10;
 var _default2 = 42;
@@ -882,7 +1030,10 @@ exports.default = _default2;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -890,6 +1041,7 @@ exports.default = _default2;
 
   reactHotLoader.register(_default, \\"_default\\", __FILENAME__);
   reactHotLoader.register(_default2, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -898,7 +1050,11 @@ exports.default = _default2;
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods arguments.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -917,13 +1073,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -932,7 +1092,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods arrow function in constructor.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -947,13 +1111,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -962,7 +1130,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods async functions expression body.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -977,13 +1149,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -992,7 +1168,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods async functions.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1009,13 +1189,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1024,7 +1208,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods block body.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1041,13 +1229,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1056,7 +1248,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods default params.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1073,13 +1269,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1088,7 +1288,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods destructured params.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1105,13 +1309,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1120,7 +1328,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods expression body.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1135,13 +1347,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1150,7 +1366,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods nested arguments.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1171,13 +1391,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1186,7 +1410,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods nested new.target.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1207,13 +1435,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1222,7 +1454,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods new.target.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1241,13 +1477,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1256,7 +1496,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods not a function.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1271,13 +1515,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1286,7 +1534,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods not an arrow function.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1303,13 +1555,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1318,7 +1574,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods same name as class method.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {
   constructor() {
@@ -1339,13 +1599,17 @@ class Foo {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1354,7 +1618,11 @@ class Foo {
 exports[`Targetting "modern" copies arrow function body block onto hidden class methods static property.js 1`] = `
 "\\"use strict\\";
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Foo {}
 
@@ -1365,13 +1633,17 @@ Foo.bar = (a, b) => {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(Foo, \\"Foo\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1391,7 +1663,11 @@ var _leftPad2 = _interopRequireDefault(_leftPad);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 const A = 42;
 function B() {
@@ -1425,7 +1701,10 @@ exports.default = _default;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -1437,6 +1716,7 @@ exports.default = _default;
   reactHotLoader.register(D, \\"D\\", __FILENAME__);
   reactHotLoader.register(E, \\"E\\", __FILENAME__);
   reactHotLoader.register(_default, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1449,7 +1729,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 class Counter {}
 
@@ -1463,7 +1747,10 @@ exports.default = _default;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -1471,6 +1758,7 @@ exports.default = _default;
 
   reactHotLoader.register(Counter, \\"Counter\\", __FILENAME__);
   reactHotLoader.register(_default, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1484,7 +1772,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
 });
 exports.spread = spread;
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 function spread(...args) {
   return args.push(1);
@@ -1492,13 +1784,17 @@ function spread(...args) {
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
   }
 
   reactHotLoader.register(spread, \\"spread\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"
@@ -1511,7 +1807,11 @@ Object.defineProperty(exports, \\"__esModule\\", {
   value: true
 });
 
-require('react-hot-loader/patch');
+(function () {
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
+
+  moduleEntry && moduleEntry.enter(module);
+})();
 
 const _default = 10;
 const _default2 = 42;
@@ -1519,7 +1819,10 @@ exports.default = _default2;
 ;
 
 (function () {
-  var reactHotLoader = require('react-hot-loader/patch').default;
+  var {
+    default: reactHotLoader,
+    moduleEntry
+  } = require('react-hot-loader/patch');
 
   if (!reactHotLoader) {
     return;
@@ -1527,6 +1830,7 @@ exports.default = _default2;
 
   reactHotLoader.register(_default, \\"_default\\", __FILENAME__);
   reactHotLoader.register(_default2, \\"default\\", __FILENAME__);
+  moduleEntry.leave(module);
 })();
 
 ;"

--- a/packages/react-hot-loader/test/__snapshots__/babel.test.js.snap
+++ b/packages/react-hot-loader/test/__snapshots__/babel.test.js.snap
@@ -39,10 +39,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -90,10 +89,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -166,10 +164,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -242,10 +239,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -293,10 +289,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -346,10 +341,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -400,10 +394,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -451,10 +444,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -508,10 +500,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -563,10 +554,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -616,10 +606,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -665,10 +654,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -716,10 +704,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -772,10 +759,9 @@ var Foo = function () {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -810,10 +796,9 @@ Foo.bar = function (a, b) {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -902,10 +887,9 @@ exports.default = _default;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -954,10 +938,9 @@ exports.default = _default;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -995,10 +978,9 @@ function spread() {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1030,10 +1012,9 @@ exports.default = _default2;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1073,10 +1054,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1111,10 +1091,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1149,10 +1128,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1189,10 +1167,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1229,10 +1206,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1269,10 +1245,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1309,10 +1284,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1347,10 +1321,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1391,10 +1364,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1435,10 +1407,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1477,10 +1448,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1515,10 +1485,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1555,10 +1524,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1599,10 +1567,9 @@ class Foo {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1633,10 +1600,9 @@ Foo.bar = (a, b) => {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1701,10 +1667,9 @@ exports.default = _default;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1747,10 +1712,9 @@ exports.default = _default;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1784,10 +1748,9 @@ function spread(...args) {
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;
@@ -1819,10 +1782,9 @@ exports.default = _default2;
 ;
 
 (function () {
-  var {
-    default: reactHotLoader,
-    moduleEntry
-  } = require('react-hot-loader/patch');
+  var reactHotLoader = require('react-hot-loader/patch').default;
+
+  var moduleEntry = require('react-hot-loader/patch').moduleEntry;
 
   if (!reactHotLoader) {
     return;

--- a/packages/react-hot-loader/test/hotModule.test.js
+++ b/packages/react-hot-loader/test/hotModule.test.js
@@ -3,6 +3,9 @@ import React from 'react'
 import { mount } from 'enzyme'
 import moduleEntry, { isModuleOpened } from '../src/hotModule'
 import hot from '../src/hot.dev'
+import logger from '../src/logger'
+
+jest.mock('../src/logger')
 
 describe('module.hot', () => {
   describe('moduleEntry', () => {
@@ -74,7 +77,7 @@ describe('module.hot', () => {
       wrapper.unmount()
     })
 
-    it('should triggen error in unmount in opened state', () => {
+    it('should trigger error in unmount in opened state', () => {
       const module = {
         id: 'error42',
       }
@@ -83,6 +86,12 @@ describe('module.hot', () => {
       const HotComponent = hot(module)(Component)
       const wrapper = mount(<HotComponent />)
       wrapper.unmount()
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(logger.error)
+        .toHaveBeenCalledWith(`React-hot-loader: Detected AppContainer unmount on module 'error42' update.
+Did you use "hot(Component)" and "ReactDOM.render()" in the same file?
+"hot(Component)" shall only be used as export.
+Please refer to "Getting Started" (https://github.com/gaearon/react-hot-loader/).`)
     })
   })
 })

--- a/packages/react-hot-loader/test/hotModule.test.js
+++ b/packages/react-hot-loader/test/hotModule.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+import React from 'react'
+import { mount } from 'enzyme'
+import moduleEntry, { isModuleOpened } from '../src/hotModule'
+import hot from '../src/hot.dev'
+
+describe('module.hot', () => {
+  describe('moduleEntry', () => {
+    it('show track execution of a module', () => {
+      const module = {
+        id: 'test42',
+      }
+
+      expect(isModuleOpened(module)).toBe(false)
+
+      moduleEntry.enter(module)
+      expect(isModuleOpened(module)).toBe(true)
+
+      moduleEntry.leave(module)
+      expect(isModuleOpened(module)).toBe(false)
+    })
+  })
+
+  describe('hot', () => {
+    it('should attach to the general hot API', () => {
+      const module = {
+        id: 42,
+        hot: {
+          accept: jest.fn(),
+        },
+      }
+
+      hot(module)
+      expect(module.hot.accept).toBeCalled()
+    })
+
+    it('should attach to webpack hot API', () => {
+      const module = {
+        id: 42,
+        hot: {
+          accept: jest.fn(),
+          status: () => 'idle',
+          addStatusHandler: jest.fn(),
+        },
+      }
+
+      hot(module)
+      expect(module.hot.accept).toBeCalled()
+      expect(module.hot.addStatusHandler).toBeCalled()
+    })
+
+    it('should not attach on HRM event', () => {
+      const module = {
+        id: 42,
+        hot: {
+          accept: jest.fn(),
+          status: () => 'not-idle',
+          addStatusHandler: jest.fn(),
+        },
+      }
+
+      hot(module)
+      expect(module.hot.accept).toBeCalled()
+      expect(module.hot.addStatusHandler).not.toBeCalled()
+    })
+
+    it('should stand mount/unmount in normal situation', () => {
+      const module = {
+        id: 42,
+      }
+      const Component = () => <div>123</div>
+      const HotComponent = hot(module)(Component)
+      const wrapper = mount(<HotComponent />)
+      wrapper.unmount()
+    })
+
+    it('should triggen error in unmount in opened state', () => {
+      const module = {
+        id: 'error42',
+      }
+      moduleEntry.enter(module)
+      const Component = () => <div>123</div>
+      const HotComponent = hot(module)(Component)
+      const wrapper = mount(<HotComponent />)
+      wrapper.unmount()
+    })
+  })
+})


### PR DESCRIPTION
Based on work done for #756, and will be a base for future investigations, but this PR is for #765 

Idea - detect the module execution start and the module execution end.
During this event HotExportedComponent could be mounted and rendered, but shall not be `unmounted`.

If this event will occur - thus means that react-dom's render method was called, and that is misconfiguration case we are trying to solve.

<img width="644" alt="screen shot 2018-01-05 at 11 07 07 pm" src="https://user-images.githubusercontent.com/582410/34608799-2dad8dde-f26e-11e7-9dc2-2a92c7089214.png">
