### PR TITLE
Fix for proxying issue with react-relay

### DIFF
--- a/packages/react-stand-in/src/createClassProxy.js
+++ b/packages/react-stand-in/src/createClassProxy.js
@@ -63,10 +63,13 @@ function createClassProxy(InitialComponent, proxyKey, wrapResult = identity) {
     render() {
       inject(this, proxyGeneration, injectedMembers)
 
-      const result = isFunctionalComponent
+      let result = isFunctionalComponent
         ? CurrentComponent(this.props, this.context)
         : CurrentComponent.prototype.render.call(this)
-
+      
+      if (!!result && !result.$$typeof && result.render){
+        result = result.render()
+      }
       return wrapResult(result)
     }
   }


### PR DESCRIPTION
Using react-relay, I was getting an error that occurred because a relay component was missing its $$typeof property. 

Relay's createFragmentContainer and createRefetchContainer functions don't actually wrap the original item at all, but rather return a new object which has it's own render method (but is not a valid element for mounting). 

I'm sure there's a cleaner fix, but couldn't think of a good one just yet...