### PR TITLE
Fix running tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "prebuild": "rm -rf packages/*/lib",
     "precommit": "lint-staged",
     "test": "yarn test:es2015 && yarn test:modern",
-    "test:es2015": "BABEL_TARGET=es2015 jest --no-cache",
-    "test:modern": "BABEL_TARGET=modern jest --no-cache"
+    "test:es2015": "cross-env BABEL_TARGET=es2015 jest --no-cache",
+    "test:modern": "cross-env BABEL_TARGET=modern jest --no-cache"
   },
   "lint-staged": {
     "*.{js,md,ts,json}": [
@@ -37,6 +37,7 @@
     "conventional-changelog-cli": "^1.3.5",
     "conventional-github-releaser": "^2.0.0",
     "create-react-class": "^15.6.2",
+    "cross-env": "^5.1.3",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/packages/react-hot-loader/test/babel.test.js
+++ b/packages/react-hot-loader/test/babel.test.js
@@ -21,7 +21,7 @@ TARGETS.forEach(target => {
             const actual = transformFileSync(fixtureFile, getOptions(target))
               .code
             const codeWithoutFilename = actual.replace(
-              new RegExp(`["']${fixtureFile}["']`, 'g'),
+              new RegExp(`["']${fixtureFile.replace(/\\/g, '/')}["']`, 'g'),
               '__FILENAME__',
             )
             expect(trim(codeWithoutFilename)).toMatchSnapshot()
@@ -39,7 +39,7 @@ TARGETS.forEach(target => {
             const actual = transformFileSync(fixtureFile, getOptions(target))
               .code
             const codeWithoutFilename = actual.replace(
-              new RegExp(`["']${fixtureFile}["']`, 'g'),
+              new RegExp(`["']${fixtureFile.replace(/\\/g, '/')}["']`, 'g'),
               '__FILENAME__',
             )
             expect(trim(codeWithoutFilename)).toMatchSnapshot()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,6 +1584,13 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3150,6 +3157,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Use `cross-env` to set environment variables
- Replace backslashes in the `__FILENAME__` replacement `RegExp`