### PR TITLE
Swallow the error during the hot-render phase.

### DIFF
--- a/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
+++ b/packages/react-hot-loader/src/reconciler/hotReplacementRender.js
@@ -260,6 +260,8 @@ export default (instance, stack) => {
     // disable reconciler to prevent upcoming components from proxying.
     reactHotLoader.disableProxyCreation = true
     hotReplacementRender(instance, stack)
+  } catch (e) {
+    logger.warn('React-hot-loader: reconcilation failed due to error', e)
   } finally {
     reactHotLoader.disableProxyCreation = false
   }


### PR DESCRIPTION
try...finally does not catch the error, one should `catch` it in real.

As result "the error" before and after HRM has the same behavior. We do not changing it now.