### PR TITLE
Bound 'hot' to module.id

### DIFF
--- a/packages/react-hot-loader/src/global/modules.js
+++ b/packages/react-hot-loader/src/global/modules.js
@@ -2,6 +2,17 @@ import logger from '../logger'
 
 const openedModules = {}
 
+const hotModules = {}
+
+const createHotModule = () => ({ instances: [], updateTimeout: 0 })
+
+export const hotModule = moduleId => {
+  if (!hotModules[moduleId]) {
+    hotModules[moduleId] = createHotModule()
+  }
+  return hotModules[moduleId]
+}
+
 export const isOpened = sourceModule =>
   sourceModule && !!openedModules[sourceModule.id]
 

--- a/packages/react-hot-loader/test/hot.dev.test.js
+++ b/packages/react-hot-loader/test/hot.dev.test.js
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { mount } from 'enzyme'
 import {
   enter as enterModule,
   leave as leaveModule,
   isOpened,
+  hotModule,
 } from '../src/global/modules'
 import hot from '../src/hot.dev'
 import logger from '../src/logger'
@@ -34,6 +35,7 @@ describe('hot (dev)', () => {
     }
 
     hot(sourceModule)
+    expect(hotModule(sourceModule.id).instances.length).toBe(0)
     expect(sourceModule.hot.accept).toHaveBeenCalledTimes(1)
     expect(sourceModule.hot.addStatusHandler).toHaveBeenCalledTimes(1)
   })
@@ -61,19 +63,61 @@ describe('hot (dev)', () => {
     wrapper.unmount()
   })
 
+  it('should redraw component on HRM', done => {
+    const callbacks = []
+    const sourceModule = {
+      id: 'error42',
+      hot: {
+        accept(callback) {
+          callbacks.push(callback)
+        },
+      },
+    }
+    const spy = jest.fn()
+    enterModule(sourceModule)
+
+    class MyComponent extends Component {
+      render() {
+        spy()
+        return <div>42</div>
+      }
+    }
+
+    const HotComponent = hot(sourceModule)(MyComponent)
+    hot(sourceModule)(MyComponent)
+    mount(<HotComponent />)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    expect(callbacks.length).toBe(2)
+    callbacks.forEach(cb => cb())
+    expect(spy).toHaveBeenCalledTimes(1)
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalledTimes(3)
+      done()
+    }, 1)
+  })
+
   it('should trigger error in unmount in opened state', () => {
-    const sourceModule = { id: 'error42' }
+    const sourceModule = { id: 'error42_unmount' }
     enterModule(sourceModule)
     const Component = () => <div>123</div>
     const HotComponent = hot(sourceModule)(Component)
-    const wrapper = mount(<HotComponent />)
-    wrapper.unmount()
+    expect(hotModule(sourceModule.id).instances.length).toBe(0)
+    const wrapper1 = mount(<HotComponent />)
+    const wrapper2 = mount(<HotComponent />)
+    expect(hotModule(sourceModule.id).instances.length).toBe(2)
+    wrapper1.unmount()
+    expect(hotModule(sourceModule.id).instances.length).toBe(1)
+
     expect(logger.error).toHaveBeenCalledTimes(1)
     expect(logger.error)
-      .toHaveBeenCalledWith(`React-hot-loader: Detected AppContainer unmount on module 'error42' update.
+      .toHaveBeenCalledWith(`React-hot-loader: Detected AppContainer unmount on module 'error42_unmount' update.
 Did you use "hot(Component)" and "ReactDOM.render()" in the same file?
 "hot(Component)" shall only be used as export.
 Please refer to "Getting Started" (https://github.com/gaearon/react-hot-loader/).`)
+
+    wrapper2.unmount()
+    expect(hotModule(sourceModule.id).instances.length).toBe(0)
   })
 
   it('it should track module state', () => {


### PR DESCRIPTION
Before - intances were tracked via local scoped variable, and in case component will unmount and mount again it will work using another instance of `instances`. 

Now - track instances via module.id.