### PR TITLE
Break cyclic dependency

### DIFF
--- a/packages/react-hot-loader/src/reconciler/proxies.js
+++ b/packages/react-hot-loader/src/reconciler/proxies.js
@@ -1,12 +1,9 @@
-import createProxy, { setConfig } from 'react-stand-in'
-import logger from '../logger'
+import createProxy from 'react-stand-in'
 
 let proxiesByID
 let idsByType
 
 let elementCount = 0
-
-setConfig({ logger })
 
 const generateTypeId = () => `auto-${elementCount++}`
 

--- a/packages/react-hot-loader/src/utils.dev.js
+++ b/packages/react-hot-loader/src/utils.dev.js
@@ -1,9 +1,11 @@
 import { getProxyByType } from './reconciler/proxies'
 import reactHotLoader from './reactHotLoader'
+import logger from './logger'
+import { setConfig as setProxyConfig } from 'react-stand-in'
+
+setProxyConfig({ logger })
 
 export const areComponentsEqual = (a, b) =>
   getProxyByType(a) === getProxyByType(b)
 
-export const setConfig = config => {
-  Object.assign(reactHotLoader.config, config)
-}
+export const setConfig = config => Object.assign(reactHotLoader.config, config)


### PR DESCRIPTION
Logger uses react-hot-loader(to get flags), which uses proxies, which uses logger to inject logger into stand-in.
As result it injects null, and stand-in will throw an NPE instead of logging anything.