### PR TITLE
add note about usage with react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ performance.
 Hot reloading code is just one line in the beginning and one line in the end of
 each module so you might not need source maps at all.
 
+## React Native
+
+React Native
+**[supports hot reloading natively](https://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html)**
+as of version 0.22.  
+
+Using React Hot Loader with React Native can cause unexpected issues (see [#824](/../../issues/824)) and is not recommended.
+
 ### Code Splitting
 
 As long most of modern react-component-loader

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ React Native
 **[supports hot reloading natively](https://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html)**
 as of version 0.22.  
 
-Using React Hot Loader with React Native can cause unexpected issues (see [#824](/../../issues/824)) and is not recommended.
+Using React Hot Loader with React Native can cause unexpected issues (see #824) and is not recommended.
 
 ### Code Splitting
 


### PR DESCRIPTION
Related to #824. Just adding a note to the readme to explicitly state that react hot loader should not be used with react native.