### PR TITLE
Compat mode. 

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -311,3 +311,19 @@ import * as React from 'react' // React is now patched
 import React from 'react'
 import { hot } from 'react-hot-loader' // React is now patched
 ```
+
+#### React-hot-loader: an instance were returned from a render function. Configuration change required
+
+React-hot-loader runs in "compatibility" mode by default. This disables some workarounds you possible might need.
+
+* **Enable** compat mode if you are using something like `react-async-bootstrapper`(react-async-component)
+* **Disable** compat mode if you are using `Relay`.
+
+There is **no** way to use them simultaneously.
+
+Buy default RHL will produce more simply and compatible code, but non-compact mode is absolutely legit for React 15+.
+
+```js
+import { setConfig } from 'react-hot-loader'
+setConfig({ compat: false })
+```

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -325,5 +325,5 @@ Buy default RHL will produce more simply and compatible code, but non-compact mo
 
 ```js
 import { setConfig } from 'react-hot-loader'
-setConfig({ compat: false })
+setConfig({ statelessIndeterminateComponent: true })
 ```

--- a/examples/styled-components/src/App.js
+++ b/examples/styled-components/src/App.js
@@ -39,6 +39,6 @@ const App = () => (
   </h1>
 )
 
-setConfig({ logLevel: 'debug' })
+setConfig({ logLevel: 'debug', statelessIndeterminateComponent: true })
 
 export default hot(module)(App)

--- a/examples/styled-components/src/App.js
+++ b/examples/styled-components/src/App.js
@@ -15,21 +15,27 @@ const SmallText = emoStyled('div')`
 const indirect = {
   element: () => (
     <SmallText>
-      hidden2 <Counter />
+      hidden <Counter />
     </SmallText>
   ),
 }
+
+const Instanced = () => new Counter()
 
 const aNumber = 10
 
 const App = () => (
   <h1>
-    <BigText>1.Hello, world!! {aNumber} </BigText>
+    <BigText>1.Hello, world {aNumber} </BigText>
     <br />
-    <SmallText>2.Hello, world---.</SmallText>
+    <SmallText>2.Hello, world.</SmallText>
     <br />
-    <Counter />
+    Counter: <Counter /> <br />
+    Hidden:
     <indirect.element />
+    <br />
+    Instanced: <Instanced />
+    <br />
   </h1>
 )
 

--- a/examples/styled-components/src/Counter.js
+++ b/examples/styled-components/src/Counter.js
@@ -15,7 +15,7 @@ class Counter extends React.Component {
   }
 
   render() {
-    return this.state.count
+    return <span>1:{this.state.count}</span>
   }
 }
 

--- a/examples/styled-components/src/Counter.js
+++ b/examples/styled-components/src/Counter.js
@@ -15,7 +15,7 @@ class Counter extends React.Component {
   }
 
   render() {
-    return <span>1:{this.state.count}</span>
+    return <span>{this.state.count}</span>
   }
 }
 

--- a/packages/react-hot-loader/src/config.js
+++ b/packages/react-hot-loader/src/config.js
@@ -1,0 +1,6 @@
+const config = {
+  logLevel: 'error',
+  compat: true,
+}
+
+export default config

--- a/packages/react-hot-loader/src/logger.js
+++ b/packages/react-hot-loader/src/logger.js
@@ -1,26 +1,24 @@
 /* eslint-disable no-console */
-import reactHotLoader from './reactHotLoader'
+import config from './config'
 
 const logger = {
   debug(...args) {
-    if (['debug'].includes(reactHotLoader.config.logLevel)) {
+    if (['debug'].includes(config.logLevel)) {
       console.debug(...args)
     }
   },
   log(...args) {
-    if (['debug', 'log'].includes(reactHotLoader.config.logLevel)) {
+    if (['debug', 'log'].includes(config.logLevel)) {
       console.log(...args)
     }
   },
   warn(...args) {
-    if (['debug', 'log', 'warn'].includes(reactHotLoader.config.logLevel)) {
+    if (['debug', 'log', 'warn'].includes(config.logLevel)) {
       console.warn(...args)
     }
   },
   error(...args) {
-    if (
-      ['debug', 'log', 'warn', 'error'].includes(reactHotLoader.config.logLevel)
-    ) {
+    if (['debug', 'log', 'warn', 'error'].includes(config.logLevel)) {
       console.error(...args)
     }
   },

--- a/packages/react-hot-loader/src/patch.dev.js
+++ b/packages/react-hot-loader/src/patch.dev.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import reactHotLoader from './reactHotLoader'
-import './utils.dev'
 
 reactHotLoader.patch(React)
 

--- a/packages/react-hot-loader/src/patch.dev.js
+++ b/packages/react-hot-loader/src/patch.dev.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import reactHotLoader from './reactHotLoader'
+import './utils.dev'
 
 reactHotLoader.patch(React)
 

--- a/packages/react-hot-loader/src/reactHotLoader.js
+++ b/packages/react-hot-loader/src/reactHotLoader.js
@@ -74,6 +74,7 @@ const reactHotLoader = {
 
   config: {
     logLevel: 'error',
+    compat: true,
   },
 }
 

--- a/packages/react-hot-loader/src/reconciler/proxies.js
+++ b/packages/react-hot-loader/src/reconciler/proxies.js
@@ -1,4 +1,5 @@
-import createProxy from 'react-stand-in'
+import createProxy, { isReactComponentInstance } from 'react-stand-in'
+import './standInAdapter'
 
 let proxiesByID
 let idsByType
@@ -11,11 +12,27 @@ export const getIdByType = type => idsByType.get(type)
 
 export const getProxyByType = type => proxiesByID[getIdByType(type)]
 
-const autoWrapper = element => {
+function autoWrapper(element) {
   // post wrap on post render
   if (!element) {
     return element
   }
+
+  if (isReactComponentInstance(element)) {
+    console.error(
+      'React-hot-loader:',
+      this,
+      ' returned an render',
+      element,
+      'as result.',
+      'You have to disable compat mode to let React-hot-loader handle this.',
+      'setConfig({statelessIndeterminateComponent: true}))',
+    )
+    throw new Error(
+      'React-hot-loader: an instance were returned from a render function. Configuration change required',
+    )
+  }
+
   if (Array.isArray(element)) {
     return element.map(autoWrapper)
   }

--- a/packages/react-hot-loader/src/reconciler/standInAdapter.js
+++ b/packages/react-hot-loader/src/reconciler/standInAdapter.js
@@ -1,0 +1,10 @@
+import { setConfig as setProxyConfig } from 'react-stand-in'
+import logger from '../logger'
+
+export const setConfig = (config = {}) =>
+  setProxyConfig({
+    logger,
+    statelessIndeterminateComponent: config.statelessIndeterminateComponent,
+  })
+
+setConfig()

--- a/packages/react-hot-loader/src/utils.dev.js
+++ b/packages/react-hot-loader/src/utils.dev.js
@@ -1,9 +1,6 @@
-import { setConfig as setProxyConfig } from 'react-stand-in'
 import { getProxyByType } from './reconciler/proxies'
-import reactHotLoader from './reactHotLoader'
-import logger from './logger'
-
-setProxyConfig({ logger, reactHotLoader: reactHotLoader.config })
+import config from './config'
+import { setConfig as configureStandin } from './reconciler/standInAdapter'
 
 const getProxyOrType = type => {
   const proxy = getProxyByType(type)
@@ -13,4 +10,5 @@ const getProxyOrType = type => {
 export const areComponentsEqual = (a, b) =>
   getProxyOrType(a) === getProxyOrType(b)
 
-export const setConfig = config => Object.assign(reactHotLoader.config, config)
+export const setConfig = newConfig =>
+  configureStandin(Object.assign(config, newConfig))

--- a/packages/react-hot-loader/src/utils.dev.js
+++ b/packages/react-hot-loader/src/utils.dev.js
@@ -1,9 +1,9 @@
+import { setConfig as setProxyConfig } from 'react-stand-in'
 import { getProxyByType } from './reconciler/proxies'
 import reactHotLoader from './reactHotLoader'
 import logger from './logger'
-import { setConfig as setProxyConfig } from 'react-stand-in'
 
-setProxyConfig({ logger })
+setProxyConfig({ logger, reactHotLoader: reactHotLoader.config })
 
 export const areComponentsEqual = (a, b) =>
   getProxyByType(a) === getProxyByType(b)

--- a/packages/react-hot-loader/test/AppContainer.dev.test.js
+++ b/packages/react-hot-loader/test/AppContainer.dev.test.js
@@ -1327,7 +1327,7 @@ describe(`AppContainer (dev)`, () => {
     it('support indeterminateComponent', () => {
       const spy = jest.fn()
 
-      setConfig({ compat: false })
+      setConfig({ statelessIndeterminateComponent: true })
 
       const AnotherComponent = () => <div>old</div>
 
@@ -1379,7 +1379,7 @@ describe(`AppContainer (dev)`, () => {
         expect(wrapper.text()).toBe('hey 44 new')
         expect(spy).toHaveBeenCalledTimes(0) // never gets called
 
-        setConfig({ compat: true })
+        setConfig({ statelessIndeterminateComponent: false })
         // How it should work
         // expect(wrapper.text()).toBe('ho 45 new');
         // expect(spy).toHaveBeenCalledTimes(2);

--- a/packages/react-hot-loader/test/AppContainer.dev.test.js
+++ b/packages/react-hot-loader/test/AppContainer.dev.test.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme'
 import { mapProps } from 'recompose'
 import AppContainer from '../lib/AppContainer.dev'
 import RHL from '../lib/reactHotLoader'
+import { setConfig } from '../lib/utils.dev'
 
 describe(`AppContainer (dev)`, () => {
   beforeEach(() => {
@@ -1304,8 +1305,29 @@ describe(`AppContainer (dev)`, () => {
       expect(wrapper.contains(<div>second</div>)).toBe(true)
     })
 
+    it('should throw in compat mode', () => {
+      class CurrentApp extends Component {
+        render() {
+          return <div>42</div>
+        }
+      }
+
+      const IndeterminateComponent = (props, context) =>
+        new CurrentApp(props, context)
+
+      expect(() =>
+        mount(
+          <AppContainer>
+            <IndeterminateComponent n={42} />
+          </AppContainer>,
+        ).toThrow(),
+      )
+    })
+
     it('support indeterminateComponent', () => {
       const spy = jest.fn()
+
+      setConfig({ compat: false })
 
       const AnotherComponent = () => <div>old</div>
 
@@ -1357,6 +1379,7 @@ describe(`AppContainer (dev)`, () => {
         expect(wrapper.text()).toBe('hey 44 new')
         expect(spy).toHaveBeenCalledTimes(0) // never gets called
 
+        setConfig({ compat: true })
         // How it should work
         // expect(wrapper.text()).toBe('ho 45 new');
         // expect(spy).toHaveBeenCalledTimes(2);

--- a/packages/react-stand-in/src/createClassProxy.js
+++ b/packages/react-stand-in/src/createClassProxy.js
@@ -87,22 +87,7 @@ function createClassProxy(InitialComponent, proxyKey, wrapResult = identity) {
       result = CurrentComponent.prototype.render.call(this)
     }
 
-    if (isReactComponentInstance(result)) {
-      console.error(
-        'React-hot-loader: ',
-        InitialComponent,
-        'returned an instance',
-        result,
-        'as result.',
-        'You have to disable compat mode to let React-hot-loader handle this.',
-        'setConfig({compat: false}))',
-      )
-      throw new Error(
-        'React-hot-loader: an instance were returned from a render function. Configuration change required',
-      )
-    }
-
-    return wrapResult(result)
+    return wrapResult.call(this, result)
   }
 
   const defineProxyMethods = Proxy => {
@@ -118,10 +103,7 @@ function createClassProxy(InitialComponent, proxyKey, wrapResult = identity) {
   let ProxyFacade
   let ProxyComponent = null
 
-  if (
-    !isFunctionalComponent ||
-    (config.reactHotLoader && config.reactHotLoader.compat)
-  ) {
+  if (!isFunctionalComponent || !config.statelessIndeterminateComponent) {
     ProxyComponent = proxyClassCreator(
       isFunctionalComponent ? Component : InitialComponent,
       postConstructionAction,

--- a/packages/react-stand-in/src/index.js
+++ b/packages/react-stand-in/src/index.js
@@ -1,3 +1,4 @@
 export * from './constants'
 export { default } from './createClassProxy'
 export { setConfig } from './config'
+export { isReactComponentInstance } from './utils'

--- a/packages/react-stand-in/test/consistency.test.js
+++ b/packages/react-stand-in/test/consistency.test.js
@@ -17,6 +17,7 @@ const createFixtures = () => ({
       __reactstandin__regenerateByEval(key, code) {
         this[key] = eval(code)
       }
+
       /* eslint-enable */
 
       render() {
@@ -35,6 +36,7 @@ const createFixtures = () => ({
       __reactstandin__regenerateByEval(key, code) {
         this[key] = eval(code)
       }
+
       /* eslint-enable */
 
       render() {
@@ -53,6 +55,7 @@ const createFixtures = () => ({
       __reactstandin__regenerateByEval(key, code) {
         this[key] = eval(code)
       }
+
       /* eslint-enable */
 
       render() {
@@ -213,6 +216,29 @@ describe('consistency', () => {
         const Proxy = proxy.get()
 
         expect(Proxy.prototype instanceof Bar).toBe(true)
+      })
+
+      it('should return Class for Stateless component', () => {
+        const StatelessComponent = () => 42
+        const proxy = createProxy(StatelessComponent)
+        const Proxy = proxy.get()
+
+        expect(Proxy.prototype instanceof React.Component).toBe(false)
+        const instance = Proxy() // this is function
+        expect(instance.render()).toBe(42)
+      })
+
+      it('should return Instance for Stateless component in non compact mode', () => {
+        setConfig({ reactHotLoader: { compat: true } })
+        const StatelessComponent = () => 42
+        const proxy = createProxy(StatelessComponent)
+        const Proxy = proxy.get()
+
+        expect(Proxy.prototype instanceof React.Component).toBe(true)
+        expect(() => Proxy()).toThrow() // this is class
+        const instance = new Proxy()
+        expect(instance.render()).toBe(42)
+        setConfig({ reactHotLoader: {} })
       })
     })
   })

--- a/packages/react-stand-in/test/consistency.test.js
+++ b/packages/react-stand-in/test/consistency.test.js
@@ -218,7 +218,8 @@ describe('consistency', () => {
         expect(Proxy.prototype instanceof Bar).toBe(true)
       })
 
-      it('should return Class for Stateless component', () => {
+      it('should return Function for Stateless component when IndeterminateComponent allowed', () => {
+        setConfig({ statelessIndeterminateComponent: true })
         const StatelessComponent = () => 42
         const proxy = createProxy(StatelessComponent)
         const Proxy = proxy.get()
@@ -226,10 +227,10 @@ describe('consistency', () => {
         expect(Proxy.prototype instanceof React.Component).toBe(false)
         const instance = Proxy() // this is function
         expect(instance.render()).toBe(42)
+        setConfig({ statelessIndeterminateComponent: false })
       })
 
-      it('should return Instance for Stateless component in non compact mode', () => {
-        setConfig({ reactHotLoader: { compat: true } })
+      it('should return Class for Stateless component by default', () => {
         const StatelessComponent = () => 42
         const proxy = createProxy(StatelessComponent)
         const Proxy = proxy.get()
@@ -238,7 +239,6 @@ describe('consistency', () => {
         expect(() => Proxy()).toThrow() // this is class
         const instance = new Proxy()
         expect(instance.render()).toBe(42)
-        setConfig({ reactHotLoader: {} })
       })
     })
   })


### PR DESCRIPTION
fixes #832, breaks #775

The idea - in beta14 we introduced a new behavior for stand-in, to be more clear - returning an instance from stateless components.
This fixes #775, but actually required __only__ by 775/Relay, but in the same time breaks react-async-component and possible related stuff, which can not handle instances from return.

Thus we got a new configuration option - compat, default to true.
In compat mode we will NOT return an instance from stateless components, but just rendering them.
In case of instance - it will throw an error, asking to change configuration.

Instance as result is far rare case, and it possible to detect that you have it, that opposite. That's why it defaults to true.

Not listing a new option in readme, as long one should not configure it before hands.
** Future generations: if you got error "an instance were returned from a render function. Configuration change required" - you know the solution *
