### PR TITLE
Regenerate overridden members

### DIFF
--- a/packages/react-stand-in/src/createClassProxy.js
+++ b/packages/react-stand-in/src/createClassProxy.js
@@ -188,7 +188,6 @@ function createClassProxy(InitialComponent, proxyKey, wrapResult = identity) {
 
     isFunctionalComponent = !isReactClass(NextComponent)
     proxyGeneration++
-    injectedMembers = {}
 
     // Save the next constructor so we call it
     const PreviousComponent = CurrentComponent
@@ -222,6 +221,7 @@ function createClassProxy(InitialComponent, proxyKey, wrapResult = identity) {
           NextComponent,
           InitialComponent,
           lastInstance,
+          injectedMembers,
         )
       }
     }

--- a/packages/react-stand-in/src/inject.js
+++ b/packages/react-stand-in/src/inject.js
@@ -14,6 +14,7 @@ function mergeComponents(
   NextComponent,
   InitialComponent,
   lastInstance,
+  injectedMembers,
 ) {
   const injectedCode = {}
   try {
@@ -79,7 +80,11 @@ function mergeComponents(
         }
 
         const nextString = String(nextAttr)
-        if (nextString !== String(prevAttr)) {
+        const injectedBefore = injectedMembers[key]
+        if (
+          nextString !== String(prevAttr) ||
+          (injectedBefore && nextString !== String(injectedBefore))
+        ) {
           if (!hasRegenerate) {
             if (
               nextString.indexOf('function') < 0 &&

--- a/packages/react-stand-in/test/consistency.test.js
+++ b/packages/react-stand-in/test/consistency.test.js
@@ -214,6 +214,57 @@ describe('consistency', () => {
 
         expect(Proxy.prototype instanceof Bar).toBe(true)
       })
+
+      it('should revert arrow member change', () => {
+        /* eslint-disable */
+        class BaseClass extends React.Component {
+          arrow = () => 42
+
+          render() {
+            return this.arrow()
+          }
+
+          __reactstandin__regenerateByEval(key, code) {
+            this[key] = eval(code)
+          }
+        }
+
+        class Update1Class extends React.Component {
+          arrow = () => 43
+
+          render() {
+            return this.arrow()
+          }
+
+          __reactstandin__regenerateByEval(key, code) {
+            this[key] = eval(code)
+          }
+        }
+
+        class Update2Class extends React.Component {
+          arrow = () => 42
+
+          render() {
+            return this.arrow()
+          }
+
+          __reactstandin__regenerateByEval(key, code) {
+            this[key] = eval(code)
+          }
+        }
+        /* eslint-enable */
+
+        const proxy = createProxy(BaseClass)
+        const Proxy = proxy.get()
+        const instance = new Proxy()
+        expect(instance.render()).toBe(42)
+
+        proxy.update(Update1Class)
+        expect(instance.render()).toBe(43)
+
+        proxy.update(Update2Class)
+        expect(instance.render()).toBe(42)
+      })
     })
   })
 


### PR DESCRIPTION
During HOT stand-in compares the old class and the new one.
It created 2 instances and checking what was changed in class creation.
If something did - it will inject changed value into the real instances. Thus the arrow function update work.

But, in case of ES6 RHL could not change the constructor, as a result it always compares the "first" version and the last one. Thus - it will not inject "not changed" method.... keeping the previously injected variant.

This PR just fixes this moment, and checking also injected values, and fixes #836