### PR TITLE
Add null check

### DIFF
--- a/src/babel.dev.js
+++ b/src/babel.dev.js
@@ -135,7 +135,7 @@ module.exports = function plugin(args) {
           node[REGISTRATIONS] = null // eslint-disable-line no-param-reassign
 
           // inject the code only if applicable
-          if (registrations.length) {
+          if (registrations && registrations.length) {
             node.body.unshift(headerTemplate())
             // Inject the generated tagging code at the very end
             // so that it is as minimally intrusive as possible.


### PR DESCRIPTION
I'm encountering an error in `babel.dev.js/exit`. It's in quite a large project, and I don't have time to figure out the reason. (It fails checking a dependency called `js-csp`). Hoping you'll consider adding this extra check.