### PR TITLE
Fix IE 11 issue

### DIFF
--- a/src/proxy/createClassProxy.js
+++ b/src/proxy/createClassProxy.js
@@ -108,7 +108,7 @@ function createClassProxy(InitialComponent, proxyKey, options) {
 
   const fakeBasePrototype = Base =>
     Object.getOwnPropertyNames(Base)
-      .filter(key => !blackListedClassMembers.includes(key))
+      .filter(key => blackListedClassMembers.indexOf(key) === -1)
       .filter(key => {
         const descriptor = Object.getOwnPropertyDescriptor(Base, key)
         return typeof descriptor.value === 'function'


### PR DESCRIPTION
People might not have a polyfill for `includes()`.
https://github.com/gaearon/react-proxy/blob/13f076b17b43a9d53c151931f3629ef1baae42e5/src/createClassProxy.js#L71

<img width="868" alt="capture d ecran 2018-02-21 a 20 40 39" src="https://user-images.githubusercontent.com/3165635/36501486-82c4ba60-1747-11e8-8ab5-31af7e74a90b.png">
