### PR TITLE
break render recursion, fix #882

### DIFF
--- a/src/reconciler/hotReplacementRender.js
+++ b/src/reconciler/hotReplacementRender.js
@@ -101,7 +101,11 @@ const render = component => {
     return []
   }
   if (isReactClass(component)) {
-    return component.render()
+    // not calling real render method to prevent call recursion.
+    // stateless componets does not have hotComponentRender
+    return component.hotComponentRender
+      ? component.hotComponentRender()
+      : component.render()
   }
   if (isArray(component)) {
     return component.map(render)

--- a/test/proxy/consistency.test.js
+++ b/test/proxy/consistency.test.js
@@ -278,6 +278,7 @@ describe('consistency', () => {
           'methodA',
           'methodB',
           'render',
+          'hotComponentRender',
           'componentDidMount',
           'componentWillReceiveProps',
           'componentWillUnmount',


### PR DESCRIPTION
Just breaking `.render` into two methods, calling the second one in subrender, to prevent MobX from render call recursion.