### PR TITLE
Move opencollective to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "husky": "^0.14.3",
     "jest": "^22.3.0",
     "lint-staged": "^6.1.1",
+    "opencollective": "^1.0.3",
     "prettier": "^1.10.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -97,7 +98,6 @@
     "fast-levenshtein": "^2.0.6",
     "global": "^4.3.0",
     "hoist-non-react-statics": "^2.5.0",
-    "opencollective": "^1.0.3",
     "prop-types": "^15.6.0",
     "shallowequal": "^1.0.2"
   },


### PR DESCRIPTION
```text
$ opencollective postinstall

     *** Thank you for using react-hot-loader! ***

Please consider donating to our open collective
     to help us maintain this package.

  https://opencollective.com/react-hot-loader/donate

                    ***
```

💩💩🤷‍♂️

It will not help to find backers. I think this is doing something opposite.

By moving to dev deps we still able to display backers and sponsors in Readme, but will not bother end users and CI tools
