### PR TITLE
fix: Proxy should keep methods own props. #918

### DIFF
--- a/test/AppContainer.dev.test.js
+++ b/test/AppContainer.dev.test.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import createReactClass from 'create-react-class'
 import { mount } from 'enzyme'
 import { mapProps } from 'recompose'
+import { polyfill } from 'react-lifecycles-compat'
 import { AppContainer } from '../src/index.dev'
 import RHL from '../src/reactHotLoader'
 import { increment as incrementGeneration } from '../src/global/generation'
@@ -1398,6 +1399,7 @@ describe(`AppContainer (dev)`, () => {
           return <div>I AM NEW CHILD</div>
         }
       }
+
       RHL.register(App, 'App3', 'test.js')
       wrapper.setProps({ children: <App /> })
       expect(spy).not.toHaveBeenCalled()
@@ -1945,6 +1947,28 @@ describe(`AppContainer (dev)`, () => {
       }
 
       expect(wrapper.text()).toBe('new render + old state + 20')
+    })
+
+    it('should work with react-lifecycle-compact', () => {
+      class Component extends React.Component {
+        static getDerivedStateFromProps() {
+          return {}
+        }
+      }
+
+      /* eslint-disable no-underscore-dangle */
+      polyfill(Component)
+      expect(
+        Component.prototype.componentWillReceiveProps
+          .__suppressDeprecationWarning,
+      ).toBe(true)
+
+      const Proxy = <Component />.type
+      expect(
+        Proxy.prototype.componentWillReceiveProps.__suppressDeprecationWarning,
+      ).toBe(true)
+
+      /* eslint-enable */
     })
   })
 })

--- a/test/proxy/instance-method.test.js
+++ b/test/proxy/instance-method.test.js
@@ -138,4 +138,33 @@ describe('instance method', () => {
       })
     })
   })
+
+  it('passes methods props thought', () => {
+    const injectedMethod = (a, b) => this[24 + a + b]
+
+    injectedMethod.staticProp = 'magic'
+
+    class App extends React.Component {
+      method() {
+        return 42
+      }
+    }
+
+    App.prototype.injectedMethod = injectedMethod
+
+    const app1 = new App()
+
+    expect(app1.injectedMethod).toBe(injectedMethod)
+    expect(app1.injectedMethod.staticProp).toBe('magic')
+    expect(String(app1.injectedMethod)).toBe(String(injectedMethod))
+
+    const Proxy = createProxy(App).get()
+
+    const app2 = new Proxy()
+
+    expect(app2.injectedMethod).not.toBe(injectedMethod)
+    expect(app2.injectedMethod.staticProp).toBe('magic')
+    expect(app2.injectedMethod.length).toBe(2)
+    expect(String(app2.injectedMethod)).toBe(String(injectedMethod))
+  })
 })


### PR DESCRIPTION
This includes name, arity, toString and everything else possible stored in the original method.

Fixes: react-lifecycle-compact uses magic props to flag "unsafe" methods.