### PR TITLE
Props shouldn’t be overwritten

### DIFF
--- a/src/reconciler/hotReplacementRender.js
+++ b/src/reconciler/hotReplacementRender.js
@@ -262,8 +262,8 @@ const hotReplacementRender = (instance, stack) => {
       // copy over props as long new component may be hidden inside them
       // child does not have all props, as long some of them can be calculated on componentMount.
       const nextProps = {
-        ...instance.props,
         ...(child.nextProps || {}),
+        ...instance.props,
         ...(child.props || {}),
       }
 

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -128,7 +128,7 @@ describe('reconciler', () => {
 
       // what props should be used? Look like the new ones
       expect(second.willUpdate.mock.calls[0]).toEqual([
-        { children: '42', newProp: true, keyId: '2' },
+        { children: '42', newProp: true, keyId: '1' },
         null,
         { children: '42', keyId: '1' },
         null,


### PR DESCRIPTION
I'm not sure what the correct functionality is, either providing the new props vs the old ones / merging them etc. But the change made in 4.1.0 is breaking and should be part of a major version.

It also seems weird to me that `componentWillUpdate` is called from react-hot-loader 🤔

Fixes https://github.com/zeit/next.js/issues/4299

<img width="1660" alt="screen shot 2018-05-08 at 11 21 00" src="https://user-images.githubusercontent.com/6324199/39750391-6677419e-52b5-11e8-8c28-c9ea927599f3.png">

`testProps` is the old way they were calculated in 4.0.0/4.1.0

`nextProps` are the new way they were calculated in 4.1.0+

My change brings back the result of `testProps` rather than `nextProps`.