### PR TITLE
fix: Context Provider could crash update, #944

### DIFF
--- a/examples/all-possible-containers/src/components/App.js
+++ b/examples/all-possible-containers/src/components/App.js
@@ -1,6 +1,9 @@
 // @flow
 import React from 'react'
 
+import Context from '../context'
+import Counter from './Counter'
+
 import ErrorBoundary from './ErrorBoundary'
 import ModalComponent from './ModalComponent'
 
@@ -15,6 +18,16 @@ import ConsumerConnectedComponent from './ConsumerConnectedComponent'
 import ConnectedChildrenAFComponent from './ConnectedChildrenAFComponent'
 import FunctionConsumerPureClassComponent from './FunctionConsumerPureClassComponent'
 import { EDIT_ME } from './_editMe'
+
+const Secret = (() => {
+  const A = () => (
+    <div>
+      component A <Counter />
+    </div>
+  )
+  const B = () => 'wrong'
+  return { A, B }
+})()
 
 class App extends React.Component {
   state = {
@@ -32,6 +45,7 @@ class App extends React.Component {
 
   render() {
     const { open, error, errorInfo } = this.state
+    const { A, B } = Secret
 
     return error ? (
       <ErrorBoundary error={error} errorInfo={errorInfo} />
@@ -60,6 +74,14 @@ class App extends React.Component {
               onRequestClose={() => this.setState({ open: false })}
             />
           )}
+          <div>
+            <Context.Provider value="42">
+              <Context.Consumer>
+                {value => (value === '42' ? <A /> : <B />)}
+              </Context.Consumer>
+            </Context.Provider>
+            <PureClassComponent />
+          </div>
         </React.Fragment>
       </div>
     )

--- a/examples/all-possible-containers/src/components/Counter.js
+++ b/examples/all-possible-containers/src/components/Counter.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+class Counter extends React.Component {
+  state = { count: 0 }
+
+  componentDidMount() {
+    this.interval = setInterval(
+      () => this.setState(prevState => ({ count: prevState.count + 1 })),
+      200,
+    )
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  render() {
+    return <div>#{this.state.count}</div>
+  }
+}
+
+export default Counter

--- a/src/reconciler/hotReplacementRender.js
+++ b/src/reconciler/hotReplacementRender.js
@@ -338,7 +338,13 @@ const hotReplacementRender = (instance, stack) => {
 
       if (isContextProvider(child)) {
         extraContext = new Map(extraContext)
-        extraContext.set(getContextProvider(child.type), child.props.value)
+        extraContext.set(
+          getContextProvider(child.type),
+          {
+            ...(child.nextProps || {}),
+            ...(child.props || {}),
+          }.value,
+        )
         childName = 'ContextProvider'
       }
 


### PR DESCRIPTION
If `Provider` lays inside `Div` we have to repeat the same trick, as we do to construct instance props - merge "next" and "current".

Right now - it will throw an error :( - https://github.com/gaearon/react-hot-loader/issues/944#issuecomment-389896885