### PR TITLE
fix: RHL babel plugin will ignore react and react-hot-loader, fixes #900

### DIFF
--- a/src/babel.dev.js
+++ b/src/babel.dev.js
@@ -4,6 +4,14 @@ const templateOptions = {
   placeholderPattern: /^([A-Z0-9]+)([A-Z0-9_]+)$/,
 }
 
+/* eslint-disable */
+const shouldIgnoreFile = file =>
+  !!file
+    .split('\\')
+    .join('/')
+    .match(/node_modules\/(react|react-hot-loader)([\/]|$)/)
+/* eslint-enable */
+
 module.exports = function plugin(args) {
   // This is a Babel plugin, but the user put it in the Webpack config.
   if (this && this.callback) {
@@ -130,12 +138,16 @@ module.exports = function plugin(args) {
           /* eslint-enable */
         },
 
-        exit({ node }) {
+        exit({ node }, { file }) {
           const registrations = node[REGISTRATIONS]
           node[REGISTRATIONS] = null // eslint-disable-line no-param-reassign
 
           // inject the code only if applicable
-          if (registrations && registrations.length) {
+          if (
+            registrations &&
+            registrations.length &&
+            !shouldIgnoreFile(file.opts.filename)
+          ) {
             node.body.unshift(headerTemplate())
             // Inject the generated tagging code at the very end
             // so that it is as minimally intrusive as possible.
@@ -191,3 +203,5 @@ module.exports = function plugin(args) {
     },
   }
 }
+
+module.exports.shouldIgnoreFile = shouldIgnoreFile

--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import { transformFileSync } from 'babel-core'
 /* eslint-disable import/no-unresolved, import/extensions */
 import { getOptions, TARGETS } from '../testConfig/babel'
+import plugin from '../src/babel.dev'
 /* eslint-enable import/no-unresolved, import/extensions */
 
 const babelPlugin = path.resolve(__dirname, '../src/babel.dev')
@@ -59,6 +60,28 @@ describe('babel', () => {
           }
         })
       })
+    })
+  })
+
+  describe('babel helpers', () => {
+    const { shouldIgnoreFile } = plugin
+    it('should ignore react and hot-loader', () => {
+      expect(shouldIgnoreFile('node_modules/react')).toBe(true)
+      expect(shouldIgnoreFile('node_modules\\react')).toBe(true)
+      expect(shouldIgnoreFile('node_modules/react/xyz')).toBe(true)
+
+      expect(shouldIgnoreFile('node_modules/react-hot-loader')).toBe(true)
+      expect(shouldIgnoreFile('node_modules/react-hot-loader/xyz')).toBe(true)
+    })
+
+    it('should pass all other files', () => {
+      expect(shouldIgnoreFile('react')).toBe(false)
+      expect(shouldIgnoreFile('node_modules/react-select')).toBe(false)
+      expect(shouldIgnoreFile('node_modules\\react-select')).toBe(false)
+      expect(shouldIgnoreFile('some_modules/react/xyz')).toBe(false)
+
+      expect(shouldIgnoreFile('node_modules/react-cold-loader')).toBe(false)
+      expect(shouldIgnoreFile('react-hot-loader.js')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
This PR just blacklist `react` and `react-hot-loader` for RHL's babel plugin, thus solving cyclic dependency.

The approach I proposed in #900, ie just exclude node_modules from babel plugin is not good idea, as long we need babel plugin __inside__ node modules for ❄️cold components, ie we need registers to blacklist by file location.