### PR TITLE
Fix hot reloading for `parcel` example

### DIFF
--- a/examples/parcel/src/App.js
+++ b/examples/parcel/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-//import { hot } from 'react-hot-loader'
+import { hot } from 'react-hot-loader'
 import Counter from './Counter'
 
 const App = () => (
@@ -9,6 +9,4 @@ const App = () => (
   </h1>
 )
 
-// DO NOT USE HOT!
-//export default hot(module)(App)
-export default App
+export default hot(module)(App)


### PR DESCRIPTION
I tried the parcel example locally, and it lost track of the counter after updating the `Counter` component.

As discussed in #1004, the `App` should be wrapped in `hot` before exporting.

This PR fixes that.

cc @theKashey