### PR TITLE
Fix class detection

### DIFF
--- a/examples/styled-components/src/App.js
+++ b/examples/styled-components/src/App.js
@@ -20,6 +20,13 @@ const indirect = {
   ),
 }
 
+const indirectStyled = {
+  DS: styled.div`
+    border: 1px solid #f00;
+  `,
+  DE: emoStyled('div')`border: 1px solid #F00`,
+}
+
 const aNumber = 100500
 
 const App = () => (
@@ -30,6 +37,14 @@ const App = () => (
     <br />
     <Counter />
     <indirect.element />
+    <indirectStyled.DS>
+      {' '}
+      indirect DS <Counter />{' '}
+    </indirectStyled.DS>
+    <indirectStyled.DE>
+      {' '}
+      indirect DE <Counter />{' '}
+    </indirectStyled.DE>
     <div>
       {[
         <span key={1}>depend on aNumber - </span>,

--- a/src/internal/reactUtils.js
+++ b/src/internal/reactUtils.js
@@ -3,8 +3,37 @@ import React from 'react'
 
 export const isCompositeComponent = type => typeof type === 'function'
 
-export const getComponentDisplayName = type =>
-  type.displayName || type.name || 'Component'
+export const getComponentDisplayName = type => {
+  const displayName = type.displayName || type.name
+  return displayName && displayName !== 'ReactComponent'
+    ? displayName
+    : 'Component'
+}
+
+export const reactLifeCycleMountMethods = [
+  'componentWillMount',
+  'componentDidMount',
+]
+
+export function isReactClass(Component) {
+  return !!(
+    Component.prototype &&
+    (React.Component.prototype.isPrototypeOf(Component.prototype) ||
+      // react 14 support
+      Component.prototype.isReactComponent ||
+      Component.prototype.componentWillMount ||
+      Component.prototype.componentWillUnmount ||
+      Component.prototype.componentDidMount ||
+      Component.prototype.componentDidUnmount ||
+      Component.prototype.render)
+  )
+}
+
+export function isReactClassInstance(Component) {
+  return (
+    Component && isReactClass({ prototype: Object.getPrototypeOf(Component) })
+  )
+}
 
 export const getInternalInstance = instance =>
   instance._reactInternalFiber || // React 16

--- a/src/proxy/createClassProxy.js
+++ b/src/proxy/createClassProxy.js
@@ -7,16 +7,14 @@ import {
   CACHED_RESULT,
   PROXY_IS_MOUNTED,
 } from './constants'
-import {
-  getDisplayName,
-  isReactClass,
-  isReactComponentInstance,
-  identity,
-  safeDefineProperty,
-  proxyClassCreator,
-} from './utils'
+import { identity, safeDefineProperty, proxyClassCreator } from './utils'
 import { inject, checkLifeCycleMethods, mergeComponents } from './inject'
 import config from '../configuration'
+import {
+  getComponentDisplayName,
+  isReactClass,
+  isReactClassInstance,
+} from '../internal/reactUtils'
 
 const has = Object.prototype.hasOwnProperty
 
@@ -267,7 +265,7 @@ function createClassProxy(InitialComponent, proxyKey, options) {
       // This is a Relay-style container constructor. We can't do the prototype-
       // style wrapping for this as we do elsewhere, so just we just pass it
       // through as-is.
-      if (isReactComponentInstance(result)) {
+      if (isReactClassInstance(result)) {
         ProxyComponent = null
 
         // Relay lazily sets statics like getDerivedStateFromProps on initial
@@ -354,7 +352,7 @@ function createClassProxy(InitialComponent, proxyKey, options) {
     CurrentComponent = NextComponent
 
     // Try to infer displayName
-    const displayName = getDisplayName(CurrentComponent)
+    const displayName = getComponentDisplayName(CurrentComponent)
 
     safeDefineProperty(ProxyFacade, 'displayName', {
       configurable: true,

--- a/src/proxy/inject.js
+++ b/src/proxy/inject.js
@@ -1,11 +1,11 @@
 import {
   isNativeFunction,
-  reactLifeCycleMountMethods,
   safeReactConstructor,
   getOwnKeys,
   shallowStringsEqual,
   deepPrototypeUpdate,
 } from './utils'
+import { reactLifeCycleMountMethods } from '../internal/reactUtils'
 import { REGENERATE_METHOD, PREFIX, GENERATION } from './constants'
 import logger from '../logger'
 

--- a/src/proxy/utils.js
+++ b/src/proxy/utils.js
@@ -1,30 +1,6 @@
 /* eslint-disable no-eval, func-names */
 import logger from '../logger'
 
-export function getDisplayName(Component) {
-  const displayName = Component.displayName || Component.name
-  return displayName && displayName !== 'ReactComponent'
-    ? displayName
-    : 'Component'
-}
-
-export const reactLifeCycleMountMethods = [
-  'componentWillMount',
-  'componentDidMount',
-]
-
-export function isReactClass(Component) {
-  return (
-    Component.prototype &&
-    (Component.prototype.isReactComponent ||
-      Component.prototype.componentWillMount ||
-      Component.prototype.componentWillUnmount ||
-      Component.prototype.componentDidMount ||
-      Component.prototype.componentDidUnmount ||
-      Component.prototype.render)
-  )
-}
-
 export function safeReactConstructor(Component, lastInstance) {
   try {
     if (lastInstance) {
@@ -80,9 +56,6 @@ const ES5ProxyComponentFactory = function(
   Object.setPrototypeOf(ProxyComponent, InitialParent)
   return ProxyComponent
 }
-
-export const isReactComponentInstance = el =>
-  el && typeof el === 'object' && !el.type && el.render
 
 export const proxyClassCreator = doesSupportClasses
   ? ES6ProxyComponentFactory

--- a/test/AppContainer.dev.test.js
+++ b/test/AppContainer.dev.test.js
@@ -263,6 +263,7 @@ describe(`AppContainer (dev)`, () => {
             return <span>works</span>
           }
         }
+        SubApp.displayName = 'SubApp'
 
         class App extends Component {
           componentWillUnmount() {
@@ -281,6 +282,7 @@ describe(`AppContainer (dev)`, () => {
             )
           }
         }
+        App.displayName = 'App'
         /* eslint-enable */
 
         incrementGeneration()
@@ -1652,7 +1654,7 @@ describe(`AppContainer (dev)`, () => {
 
       /* eslint-enable */
 
-      const expectUnmounts = [false, false, true, true, false]
+      const expectUnmounts = [false, false, true, true, true]
       generateChilds()
       ;[ChildB, ChildC, ChildD, ChildE, ChildF].forEach((Replace, index) => {
         const expectUnmount = expectUnmounts[index]

--- a/test/internal/reactUtils.test.js
+++ b/test/internal/reactUtils.test.js
@@ -5,9 +5,33 @@ import {
   getComponentDisplayName,
   getInternalInstance,
   updateInstance,
+  isReactClass,
+  isReactClassInstance,
 } from '../../src/internal/reactUtils'
 
 describe('reactUtils', () => {
+  describe('isReact', () => {
+    it('isReactClass', () => {
+      class C1 extends React.Component {}
+      class C2 extends C1 {}
+      const F1 = () => 42
+
+      expect(isReactClass(F1)).toBe(false)
+      expect(isReactClass(C1)).toBe(true)
+      expect(isReactClass(C2)).toBe(true)
+    })
+
+    it('isReactClassInstance', () => {
+      class C1 extends React.Component {}
+      class C2 extends C1 {}
+      const F1 = function F1() {}
+
+      expect(isReactClassInstance(new F1())).toBe(false)
+      expect(isReactClassInstance(new C1())).toBe(true)
+      expect(isReactClassInstance(new C2())).toBe(true)
+    })
+  })
+
   describe('#isCompositeComponent', () => {
     it('should return true if this is a composite component', () => {
       const FunctionalComponent = () => null


### PR DESCRIPTION
Actually this fixes only one problem - `isSwappable` for components with React.Component deeper in the prototype chain.
For example - StyledComponents extends another StyledComponents, which extends React.Component - our tests thinks that it's a function, as long all the things we are looking fox exists in proto-prototype.

Meanwhile I am trying to clean some duplications.