### PR TITLE
fix: element could be double-proxied

### DIFF
--- a/src/reactHotLoader.js
+++ b/src/reactHotLoader.js
@@ -4,6 +4,7 @@ import { increment as incrementGeneration } from './global/generation'
 import {
   updateProxyById,
   resetProxies,
+  isProxyType,
   getProxyByType,
   getProxyById,
   createProxyForType,
@@ -15,7 +16,12 @@ import logger from './logger'
 import { preactAdapter } from './adapters/preact'
 
 function resolveType(type) {
-  if (!isCompositeComponent(type) || isTypeBlacklisted(type)) return type
+  if (
+    !isCompositeComponent(type) ||
+    isTypeBlacklisted(type) ||
+    isProxyType(type)
+  )
+    return type
 
   const proxy = reactHotLoader.disableProxyCreation
     ? getProxyByType(type)

--- a/src/reconciler/proxies.js
+++ b/src/reconciler/proxies.js
@@ -1,4 +1,4 @@
-import createProxy from '../proxy'
+import createProxy, { PROXY_KEY } from '../proxy'
 import { resetClassProxies } from '../proxy/createClassProxy'
 
 let proxiesByID
@@ -11,6 +11,7 @@ let renderOptions = {}
 const generateTypeId = () => `auto-${elementCount++}`
 
 export const getIdByType = type => idsByType.get(type)
+export const isProxyType = type => type[PROXY_KEY]
 
 export const getProxyById = id => proxiesByID[id]
 export const getProxyByType = type => getProxyById(getIdByType(type))

--- a/test/reactHotLoader.test.js
+++ b/test/reactHotLoader.test.js
@@ -140,6 +140,18 @@ describe('reactHotLoader', () => {
       expect(proxyElement.type[UNWRAP_PROXY]()).toBe(Span)
     })
 
+    it('should not double-proxy', () => {
+      const Component1 = () => <div>42</div>
+      const Element1 = <Component1 />
+      const Type1 = Element1.type
+      const Element2 = <Type1 />
+      const Element3 = React.Children.only(Element1)
+      const Element4 = React.cloneElement(Element1)
+      expect(Element1.type).toBe(Element2.type)
+      expect(Element1.type).toBe(Element3.type)
+      expect(Element1.type).toBe(Element4.type)
+    })
+
     it('should result into shadowing the original component', () => {
       // Registering Div
       reactHotLoader.register(Div, 'Div', 'reactHotLoader.test.js')


### PR DESCRIPTION
Still walking around React+TypeScript solution, trying to find a better(a faster) way to handle it (@Akuukis, I did not forget about your PR), and this is yet another finding.

Bug: components could be double proxied, if someone, by some reason uses "pre-proxied" version or RHL.