### PR TITLE
Fix parcel example

### DIFF
--- a/examples/parcel/package.json
+++ b/examples/parcel/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "parcel"
+    "start": "parcel index.html"
   },
   "devDependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
Parcel example on the newer versions shows a 404 error on `npm start`.

Changing the start scripts to `parcel index.html` fixes the issue