### PR TITLE
fix: don't inadvertendly call getters

### DIFF
--- a/src/reconciler/hotReplacementRender.js
+++ b/src/reconciler/hotReplacementRender.js
@@ -81,11 +81,16 @@ const equalClasses = (a, b) => {
   let misses = 0
   let comparisons = 0
   Object.getOwnPropertyNames(prototypeA).forEach(key => {
-    if (typeof prototypeA[key] === 'function' && key !== 'constructor') {
+    const descriptorA = Object.getOwnPropertyDescriptor(prototypeA, key)
+    const valueA =
+      descriptorA && (descriptorA.value || descriptorA.get || descriptorA.set)
+    const descriptorB = Object.getOwnPropertyDescriptor(prototypeB, key)
+    const valueB =
+      descriptorB && (descriptorB.value || descriptorB.get || descriptorB.set)
+
+    if (typeof valueA === 'function' && key !== 'constructor') {
       comparisons++
-      if (
-        haveTextSimilarity(String(prototypeA[key]), String(prototypeB[key]))
-      ) {
+      if (haveTextSimilarity(String(valueA), String(valueB))) {
         hits++
       } else {
         misses++


### PR DESCRIPTION
:wave: Hey folks! I'm submitting this patch to cover a small bug that I noticed in the RHL reconciler logic. I was working with a component that included a getter function which tried to access `this`, and hot reloading kept failing with the following error:

```
react-hot-loader.development.js:181 React-hot-loader: reconcilation failed due to error TypeError: Cannot read property 'authors' of undefined
    at PureComponent.get (post.js:69)
    at react-hot-loader.development.js:1171
    at Array.forEach (<anonymous>)
    at equalClasses (react-hot-loader.development.js:1170)
    at areSwappable (react-hot-loader.development.js:1196)
    at react-hot-loader.development.js:1430
    at Array.forEach (<anonymous>)
    at hotReplacementRender (react-hot-loader.development.js:1347)
    at next (react-hot-loader.development.js:1360)
    at react-hot-loader.development.js:1415
```

Taking a look at the code, I noticed that RHL was grabbing the prototype's property values directly, which was causing it to _execute_ the getter without a `this` context 😱. This change adjusts that logic to use `Object.getOwnPropertyDescriptor`, making the access safe and resolving any issues with unbound functions.

Thanks for considering it, and for all your hard work on RHL!