### PR TITLE
Auto-disable RHL in unsupported environments

### DIFF
--- a/examples/styled-components/index_csp.html
+++ b/examples/styled-components/index_csp.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src http:">
+</head>
+<body>
+</body>
+</html>

--- a/examples/styled-components/webpack.config.babel.js
+++ b/examples/styled-components/webpack.config.babel.js
@@ -27,5 +27,11 @@ module.exports = {
       ),
     },
   },
-  plugins: [new HtmlWebpackPlugin(), new webpack.NamedModulesPlugin()],
+  plugins: [
+    new HtmlWebpackPlugin({
+      // uncomment this line to test RHL in "secure" env
+      // template: "index_csp.html",
+    }),
+    new webpack.NamedModulesPlugin(),
+  ],
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,20 @@
 'use strict'
 
-if (!module.hot || process.env.NODE_ENV === 'production') {
+let evalAllowed = false;
+try {
+  eval('evalAllowed = true');
+} catch (e) {
+  // eval not allowed due to CSP
+}
+
+// RHL needs setPrototypeOf to operate Component inheritance, and eval to patch methods
+const platformSupported = !!Object.setPrototypeOf && evalAllowed;
+
+if (!module.hot || process.env.NODE_ENV === 'production' || !platformSupported) {
+  if (module.hot) {
+    // we are not in prod mode, but RHL could not be activated
+    console.warn('React-Hot-Loaded is not supported in this environment');
+  }
   module.exports = require('./dist/react-hot-loader.production.min.js');
 } else {
   module.exports = require('./dist/react-hot-loader.development.js');


### PR DESCRIPTION
fixes #1071 - RHL will work in prod mode for IE10, 
fixes #917 - RHL will work in prod mode if `eval` is not allowed