### PR TITLE
Fix_Grammar_Mistake_OpenedModules_Console_Warning_Comment

### DIFF
--- a/src/global/modules.js
+++ b/src/global/modules.js
@@ -21,7 +21,7 @@ export const enter = sourceModule => {
     openedModules[sourceModule.id] = true
   } else {
     logger.warn(
-      'React-hot-loader: no `module` variable found. Do you shadow system variable?',
+      'React-hot-loader: no `module` variable found. Did you shadow a system variable?',
     )
   }
 }


### PR DESCRIPTION
Fix a grammar mistake in console.warning code comment.