### PR TITLE
Remove generational methods

### DIFF
--- a/src/proxy/createClassProxy.js
+++ b/src/proxy/createClassProxy.js
@@ -37,6 +37,10 @@ const blackListedClassMembers = [
   'getDefaultProps',
 ]
 
+const generationallyRemovedMembers = [
+  'shouldComponentUpdate'
+]
+
 const defaultRenderOptions = {
   componentWillRender: identity,
   componentDidUpdate: result => result,
@@ -379,6 +383,13 @@ function createClassProxy(InitialComponent, proxyKey, options) {
     } else {
       const classHotReplacement = () => {
         checkLifeCycleMethods(ProxyComponent, NextComponent)
+        if (proxyGeneration > 1) {
+          generationallyRemovedMembers.forEach(methodName => {
+            if (has.call(ProxyComponent.prototype, methodName) && !has.call(NextComponent.prototype, methodName)) {
+              delete ProxyComponent.prototype[methodName];
+            }
+          })
+        }
         Object.setPrototypeOf(ProxyComponent.prototype, NextComponent.prototype)
         defineProxyMethods(ProxyComponent, NextComponent.prototype)
         if (proxyGeneration > 1) {

--- a/src/proxy/createClassProxy.js
+++ b/src/proxy/createClassProxy.js
@@ -6,6 +6,7 @@ import {
   UNWRAP_PROXY,
   CACHED_RESULT,
   PROXY_IS_MOUNTED,
+  PREFIX,
 } from './constants'
 import { identity, safeDefineProperty, proxyClassCreator } from './utils'
 import { inject, checkLifeCycleMethods, mergeComponents } from './inject'
@@ -37,15 +38,22 @@ const blackListedClassMembers = [
   'getDefaultProps',
 ]
 
-const generationallyRemovedMembers = [
-  'shouldComponentUpdate'
-]
-
 const defaultRenderOptions = {
   componentWillRender: identity,
   componentDidUpdate: result => result,
   componentDidRender: result => result,
 }
+
+const filteredPrototypeMethods = Proto =>
+  Object.getOwnPropertyNames(Proto).filter(prop => {
+    const descriptor = Object.getOwnPropertyDescriptor(Proto, prop)
+    return (
+      descriptor &&
+      !prop.startsWith(PREFIX) &&
+      !blackListedClassMembers.includes(prop) &&
+      typeof descriptor.value === 'function'
+    )
+  })
 
 const defineClassMember = (Class, methodName, methodBody) =>
   safeDefineProperty(Class.prototype, methodName, {
@@ -156,17 +164,11 @@ function createClassProxy(InitialComponent, proxyKey, options) {
     }, realMethod)
   }
 
-  const fakeBasePrototype = Base =>
-    Object.getOwnPropertyNames(Base)
-      .filter(key => blackListedClassMembers.indexOf(key) === -1)
-      .filter(key => {
-        const descriptor = Object.getOwnPropertyDescriptor(Base, key)
-        return typeof descriptor.value === 'function'
-      })
-      .reduce((acc, key) => {
-        acc[key] = methodWrapperFactory(key, Base[key])
-        return acc
-      }, {})
+  const fakeBasePrototype = Proto =>
+    filteredPrototypeMethods(Proto).reduce((acc, key) => {
+      acc[key] = methodWrapperFactory(key, Proto[key])
+      return acc
+    }, {})
 
   const componentDidMount = lifeCycleWrapperFactory(
     'componentDidMount',
@@ -384,11 +386,13 @@ function createClassProxy(InitialComponent, proxyKey, options) {
       const classHotReplacement = () => {
         checkLifeCycleMethods(ProxyComponent, NextComponent)
         if (proxyGeneration > 1) {
-          generationallyRemovedMembers.forEach(methodName => {
-            if (has.call(ProxyComponent.prototype, methodName) && !has.call(NextComponent.prototype, methodName)) {
-              delete ProxyComponent.prototype[methodName];
-            }
-          })
+          filteredPrototypeMethods(ProxyComponent.prototype).forEach(
+            methodName => {
+              if (!has.call(NextComponent.prototype, methodName)) {
+                delete ProxyComponent.prototype[methodName]
+              }
+            },
+          )
         }
         Object.setPrototypeOf(ProxyComponent.prototype, NextComponent.prototype)
         defineProxyMethods(ProxyComponent, NextComponent.prototype)

--- a/test/proxy/instance-method.test.js
+++ b/test/proxy/instance-method.test.js
@@ -133,14 +133,14 @@ describe('instance method', () => {
         const Proxy = proxy.get()
         const wrapper = mount(<Proxy />)
         expect(wrapper.text()).toEqual('Component')
-        expect(typeof wrapper.instance().shouldComponentUpdate).toBe('function')
+        expect(wrapper.instance()).toHaveProperty('shouldComponentUpdate')
 
         proxy.update(IsPureComponent)
         wrapper.instance().forceUpdate()
 
         mount(<Proxy />)
         expect(wrapper.text()).toEqual('PureComponent')
-        expect(wrapper.instance().shouldComponentUpdate).toBeUndefined()
+        expect(wrapper.instance()).not.toHaveProperty('shouldComponentUpdate')
       })
 
       it('cant handle bound methods', () => {

--- a/test/proxy/instance-method.test.js
+++ b/test/proxy/instance-method.test.js
@@ -68,6 +68,22 @@ const createFixtures = () => ({
         return <span>{this.state.counter}</span>
       }
     },
+
+    NotPureComponent: class NotPureComponent extends React.Component {
+      shouldComponentUpdate() {
+        return true
+      }
+
+      render() {
+        return <span>Component</span>
+      }
+    },
+
+    IsPureComponent: class IsPureComponent extends React.PureComponent {
+      render() {
+        return <span>PureComponent</span>
+      }
+    },
   },
 })
 
@@ -109,6 +125,22 @@ describe('instance method', () => {
         wrapper.instance().increment()
         mount(<Proxy />)
         expect(wrapper.text()).toEqual('111')
+      })
+
+      it('removes shouldComponentUpdate', () => {
+        const { IsPureComponent, NotPureComponent } = createFixtures()[type]
+        const proxy = createProxy(NotPureComponent)
+        const Proxy = proxy.get()
+        const wrapper = mount(<Proxy />)
+        expect(wrapper.text()).toEqual('Component')
+        expect(typeof wrapper.instance().shouldComponentUpdate).toBe('function')
+
+        proxy.update(IsPureComponent)
+        wrapper.instance().forceUpdate()
+
+        mount(<Proxy />)
+        expect(wrapper.text()).toEqual('PureComponent')
+        expect(wrapper.instance().shouldComponentUpdate).toBeUndefined()
       })
 
       it('cant handle bound methods', () => {


### PR DESCRIPTION
Adds a check on successive `proxyGeneration` iterations against a 
 `generationallyRemovedMembers` array - removing any matches if they have been removed from the component on the next generation.

This is specifically to remove `shouldComponentUpdate` and make it so the errors with changing to a `PureComponent` do not occur, however the `generationallyRemovedMembers` array is used in case other examples of this come up in the future.

See #1089 

**Note:** updated PR #1090 to do PR from branch as mentioned in Contributors guidelines.

