### PR TITLE
Support babel 7 for hot-dropping

### DIFF
--- a/src/babel.prod.js
+++ b/src/babel.prod.js
@@ -18,7 +18,6 @@ function isImportedFromRHL(path, name) {
 
 function getRHLContext(file) {
   const context = []
-  const importSpecifiers = []
   const { body } = file.ast.program
 
   for (let i = 0; i < body.length; i++) {
@@ -33,7 +32,7 @@ function getRHLContext(file) {
       const specifier = specifiers[j]
 
       if (specifier.type === 'ImportNamespaceSpecifier') {
-        importSpecifiers.push({
+        context.push({
           kind: 'namespace',
           local: specifier.local.name,
         })
@@ -41,25 +40,18 @@ function getRHLContext(file) {
         specifier.type === 'ImportSpecifier' ||
         specifier.type === 'ImportDefaultSpecifier'
       ) {
-        importSpecifiers.push({
+        const specifierData = {
           kind: 'named',
           local: specifier.local.name,
           imported: specifier.imported
             ? specifier.imported.name
             : specifier.local.name,
-        })
+        }
+
+        if (specifierData.imported === 'hot') {
+          context.push(specifierData)
+        }
       }
-    }
-  }
-
-  for (let j = 0; j < importSpecifiers.length; j++) {
-    const specifier = importSpecifiers[j]
-
-    if (
-      (specifier.kind === 'named' && specifier.imported === 'hot') ||
-      specifier.kind === 'namespace'
-    ) {
-      context.push(specifier)
     }
   }
 

--- a/src/babel.prod.js
+++ b/src/babel.prod.js
@@ -6,7 +6,6 @@ function isImportedFromRHL(path, name) {
 
   if (
     bindingType === 'ImportSpecifier' ||
-    bindingType === 'ImportDefaultSpecifier' ||
     bindingType === 'ImportNamespaceSpecifier'
   ) {
     const bindingParent = binding.path.parent
@@ -36,19 +35,13 @@ function getRHLContext(file) {
           kind: 'namespace',
           local: specifier.local.name,
         })
-      } else if (
-        specifier.type === 'ImportSpecifier' ||
-        specifier.type === 'ImportDefaultSpecifier'
-      ) {
+      } else if (specifier.type === 'ImportSpecifier') {
         const specifierData = {
           kind: 'named',
           local: specifier.local.name,
-          imported: specifier.imported
-            ? specifier.imported.name
-            : specifier.local.name,
         }
 
-        if (specifierData.imported === 'hot') {
+        if (specifier.imported.name === 'hot') {
           context.push(specifierData)
         }
       }

--- a/test/__babel_fixtures__/drop-hot.prod.js
+++ b/test/__babel_fixtures__/drop-hot.prod.js
@@ -2,8 +2,10 @@ import React from 'react'
 import { hot, foo } from 'react-hot-loader'
 import { hot as namedHot, foo as namedFoo } from 'react-hot-loader'
 import { hot as namedHot2 } from 'react-hot-loader'
+import { hot as notRHLHot } from 'not-react-hot-loader'
 import * as RHL from 'react-hot-loader'
 import * as RHL2 from 'react-hot-loader'
+import * as NOTRHL from 'not-react-hot-loader'
 
 const App = () => <div>Hello World!</div>
 
@@ -14,7 +16,9 @@ const d = RHL.hot(module)(App);
 const e = RHL2.hot(module)(App);
 
 foo(module)(App);
+notRHLHot(module)(App);
 namedFoo(module)(App);
 RHL.foo(module)(App);
+NOTRHL.hot(module)(App);
 
 export { a, b, c, d, e };

--- a/test/__snapshots__/babel.test.js.snap
+++ b/test/__snapshots__/babel.test.js.snap
@@ -1002,6 +1002,10 @@ var RHL = _interopRequireWildcard(_reactHotLoader);
 
 var RHL2 = _interopRequireWildcard(_reactHotLoader);
 
+var _notReactHotLoader = require('not-react-hot-loader');
+
+var NOTRHL = _interopRequireWildcard(_notReactHotLoader);
+
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -1021,8 +1025,10 @@ var d = App;
 var e = App;
 
 (0, _reactHotLoader.foo)(module)(App);
+(0, _notReactHotLoader.hot)(module)(App);
 (0, _reactHotLoader.foo)(module)(App);
 RHL.foo(module)(App);
+NOTRHL.hot(module)(App);
 
 exports.a = a;
 exports.b = b;
@@ -1853,6 +1859,10 @@ var RHL = _interopRequireWildcard(_reactHotLoader);
 
 var RHL2 = _interopRequireWildcard(_reactHotLoader);
 
+var _notReactHotLoader = require('not-react-hot-loader');
+
+var NOTRHL = _interopRequireWildcard(_notReactHotLoader);
+
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -1870,8 +1880,10 @@ const d = App;
 const e = App;
 
 (0, _reactHotLoader.foo)(module)(App);
+(0, _notReactHotLoader.hot)(module)(App);
 (0, _reactHotLoader.foo)(module)(App);
 RHL.foo(module)(App);
+NOTRHL.hot(module)(App);
 
 exports.a = a;
 exports.b = b;


### PR DESCRIPTION
Earlier, the plugin used a preset-specific stuff (e.g. `metadata.modules.import`) and this cause to hot-dropping may not work with babel 7.
Now we are working with AST directly
Moreover, default import support was dropped, cause RHL exports nothing in `default`