### PR TITLE
Add sideEffects declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "patch.js",
     "react-hot-loader.d.ts"
   ],
+  "sideEffects": false,
   "keywords": [
     "react",
     "javascript",


### PR DESCRIPTION
This provides a hint to webpack and other bundlers that they may safely drop the `react-hot-loader` module if none of the imports are being used.

See:
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

Fixes #1095.