### PR TITLE
Fix react-hot-loader alias path to node_modules

### DIFF
--- a/examples/typescript/webpack.config.babel.js
+++ b/examples/typescript/webpack.config.babel.js
@@ -21,7 +21,7 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
     alias: {
-      'react-hot-loader': path.resolve(path.join(__dirname, './../../')),
+      'react-hot-loader': path.resolve(path.join(__dirname, './node_modules/react-hot-loader')),
       react: path.resolve(path.join(__dirname, './node_modules/react')),
     },
   },


### PR DESCRIPTION
The path in the webpack config for the react-hot-loader alias was pointing to a non-existent library which was preventing anyone who cloned this example from compiling. Changed to point to the node_module library.