### PR TITLE
feat: allow to work with files located outside current project

### DIFF
--- a/src/babel.dev.js
+++ b/src/babel.dev.js
@@ -1,8 +1,11 @@
+import path from 'path'
 import { REGENERATE_METHOD } from './internal/constants'
 
 const templateOptions = {
   placeholderPattern: /^([A-Z0-9]+)([A-Z0-9_]+)$/,
 }
+
+const getPackageAbsolutePath = () => path.resolve(`${__dirname}/..`)
 
 /* eslint-disable */
 const shouldIgnoreFile = file =>
@@ -27,13 +30,15 @@ module.exports = function plugin(args) {
   }
   const { types: t, template } = args
 
+  const packageAbsolutePath = module.exports.getPackageAbsolutePath()
+
   const buildRegistration = template(
     'reactHotLoader.register(ID, NAME, FILENAME);',
     templateOptions,
   )
   const headerTemplate = template(
     `(function () {
-       var enterModule = require('react-hot-loader').enterModule;
+       var enterModule = require('${packageAbsolutePath}').enterModule;
        enterModule && enterModule(module);
      }())`,
     templateOptions,
@@ -45,8 +50,8 @@ module.exports = function plugin(args) {
   const buildTagger = template(
     `
 (function () {
-  var reactHotLoader = require('react-hot-loader').default;
-  var leaveModule = require('react-hot-loader').leaveModule;
+  var reactHotLoader = require('${packageAbsolutePath}').default;
+  var leaveModule = require('${packageAbsolutePath}').leaveModule;
 
   if (!reactHotLoader) {
     return;
@@ -208,3 +213,4 @@ module.exports = function plugin(args) {
 }
 
 module.exports.shouldIgnoreFile = shouldIgnoreFile
+module.exports.getPackageAbsolutePath = getPackageAbsolutePath

--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -20,6 +20,13 @@ function addRHLPlugin(babel, prod = false) {
   return babel
 }
 
+const getPackageAbsolutePathSpy = jest.spyOn(plugin, 'getPackageAbsolutePath')
+getPackageAbsolutePathSpy.mockReturnValue('react-hot-loader')
+
+afterAll(() => {
+  getPackageAbsolutePathSpy.mockRestore()
+})
+
 describe('babel', () => {
   TARGETS.forEach(target => {
     describe(`Targetting "${target}"`, () => {


### PR DESCRIPTION
use absolute path to work with files located outside the project where `react-hot-loader` is installed.