### PR TITLE
Initialize error overlay when DOM is loaded

### DIFF
--- a/src/errorReporter.js
+++ b/src/errorReporter.js
@@ -105,17 +105,27 @@ class ErrorOverlay extends React.Component {
 }
 
 const initErrorOverlay = () => {
-  let div = document.querySelector('.react-hot-loader-error-overlay')
-  if (!div) {
-    div = document.createElement('div')
-    div.className = 'react-hot-loader-error-overlay'
-    document.body.appendChild(div)
+  const doInit = () => {
+    let div = document.querySelector('.react-hot-loader-error-overlay')
+    if (!div) {
+      div = document.createElement('div')
+      div.className = 'react-hot-loader-error-overlay'
+      document.body.appendChild(div)
+    }
+    if (lastError.length) {
+      const Overlay = configuration.ErrorOverlay || ErrorOverlay
+      ReactDom.render(<Overlay errors={lastError} />, div)
+    } else {
+      div.parentNode.removeChild(div)
+    }
   }
-  if (lastError.length) {
-    const Overlay = configuration.ErrorOverlay || ErrorOverlay
-    ReactDom.render(<Overlay errors={lastError} />, div)
+
+  // document.body may not exist yet if the DOM is not fully loaded
+  // this can happen if this is loaded from a sync script in <head>
+  if (document.body) {
+    doInit()
   } else {
-    div.parentNode.removeChild(div)
+    document.addEventListener('DOMContentLoaded', doInit)
   }
 }
 


### PR DESCRIPTION
Initialize error overlay when DOM is loaded, otherwise `document.body` may not exist yet.

My only change is wrapping `initErrorOverlay` in `document.addEventListener('DOMContentLoaded')`.

Fixes #1127 (more details here).

I tested this with my app (using `yarn link`) and it fixed the error when the `<script>` tag is in `<head>`.