### PR TITLE
Use function component instead of class in prod

### DIFF
--- a/src/AppContainer.prod.js
+++ b/src/AppContainer.prod.js
@@ -2,10 +2,8 @@
 
 import React from 'react'
 
-class AppContainer extends React.Component {
-  render() {
-    return React.Children.only(this.props.children)
-  }
+function AppContainer(props) {
+  return React.Children.only(props.children)
 }
 
 export default AppContainer


### PR DESCRIPTION
I noticed that the prod build is currently 1.43 KiB.
https://unpkg.com/react-hot-loader@4.6.3/dist/

It looks like most of the weight comes in because the AppContainer
component is a class

https://github.com/gaearon/react-hot-loader/blob/015fcf09f/src/AppContainer.prod.js#L5-L9

We can avoid most of this weight by using a function component instead
of a class here.

Fixes #1154