### PR TITLE
Added TypeScript definition for `module.hot`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,13 @@
 import * as React from 'react'
 
+declare global {
+  interface NodeModule {
+    hot?: {
+      accept(modulePath: string, reload: Function): void;
+    };
+  }
+}
+
 interface ErrorReporterProps {
   error: any
 }


### PR DESCRIPTION
The TypeScript definition didn't include `module.hot`, which led to type-checking errors in TypeScript projects.

This PR augments the global `NodeModule` interface, adding an optional `hot` property.