### PR TITLE
Introduce react-hot-reload.macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ export default hot(module)(App)
 
 Users [report](https://github.com/gaearon/react-hot-loader/pull/729#issuecomment-354097936), that it is possible to use [react-app-rewire-hot-loader](https://github.com/cdharris/react-app-rewire-hot-loader) to setup React-hot-loader without ejecting.
 
+Also, [react-hot-reload.macro](https://github.com/cometkim/react-hot-reload.macro) provides limited support of React Hot Loader in zero configuration.
+
 ### TypeScript
 
 As of version 4, React Hot Loader requires you to pass your code through [Babel](http://babeljs.io/) to transform it so that it can be hot-reloaded. This can be a pain point for TypeScript users, who usually do not need to integrate Babel as part of their build process.


### PR DESCRIPTION
Hi forks.

This PR simply introduced [react-hot-reload.macro](https://github.com/cometkim/react-hot-reload.macro) as an alternative option in README, without ejecting section.

It has limitations(only support `hot()`) but I believe it's the simplest way to use RHL.