### PR TITLE
Fix Parcel example

### DIFF
--- a/examples/parcel/src/App.js
+++ b/examples/parcel/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { hot } from 'react-hot-loader/root'
+import { hot } from 'react-hot-loader'
 import Counter from './Counter'
 
 const App = () => (
@@ -9,4 +9,4 @@ const App = () => (
   </h1>
 )
 
-export default hot(App)
+export default hot(module)(App)


### PR DESCRIPTION
Resolves #1191 

According to the README the new `root` API isn't supported with Parcel, but the example was updated to use it. This switches back to the old `hot` API.