### PR TITLE
More docs for linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,41 @@ performance.
 Hot reloading code is just one line in the beginning and one line at the end of
 each module so you might not need source maps at all.
 
+### Linking
+
+If you are using `npm link` or `yarn link` for development purposes, there is a chance you will get error `Module not found: Error: Cannot resolve module 'react-hot-loader'` or the linked package is not hot reloaded.
+
+There are 2 ways to fix `Module not found`:
+
+- Use [`include` in loader configuration](https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L22) to only opt-in your app's files to processing.
+- Alternatively if you are using webpack, override the module resolution in your config:
+
+```js
+{
+  resolve: {
+    alias: {
+      'react-hot-loader': path.resolve(path.join(__dirname, './node_modules/react-hot-loader')),
+    }
+  }
+}
+```
+
+And to make your linked package to be hot reloaded, it will need to use the patched version of `react` and `react-dom`, if you're using webpack, add this options to the alias config
+
+```js
+{
+  resolve: {
+    alias: {
+      'react-hot-loader': path.resolve(path.join(__dirname, './node_modules/react-hot-loader')),
+      // add these 2 lines below so linked package will reference the patched version of `react` and `react-dom`
+      'react': path.resolve(path.join(__dirname, './node_modules/react')),
+      'react-dom': path.resolve(path.join(__dirname, './node_modules/react-dom')),
+      // or point react-dom above to './node_modules/@hot-loader/react-dom' if you are using React-🔥-Dom
+    }
+  }
+}
+```
+
 ## Preact
 
 React-hot-loader should work out of the box with `preact-compat`, but, in case of pure preact, you will need

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -87,9 +87,9 @@ module.exports = {
 
 If you used WebpackDevServer CLI mode and after switching to Node it crashes with `Error: Invalid path ''`, you probably didn't have `path` specified in `output` at all. You can just put `path: __dirname` there, as it won't matter for development config.
 
-### Module not found: Error: Cannot resolve module 'react-hot'
+### Module not found: Error: Cannot resolve module 'react-hot-loader'
 
-Most likely you used `npm link` to use a development version of a package in a different folder, and React Hot Loader processed it by mistake. You should use [`include` in loader configuration](https://github.com/gaearon/react-hot-boilerplate/blob/master/webpack.config.js#L22) to only opt-in your app's files to processing.
+Most likely you used `npm link` or `yarn link` to use a development version of a package in a different folder, and React Hot Loader processed it by mistake. Read the guide about linking package in [README linking section](../README.md#linking)
 
 ---
 


### PR DESCRIPTION
Had error with linking just recently, and it's a bit hard to find the docs for linking until I found the answer by @theKashey in https://github.com/gaearon/react-hot-loader/issues/1237#issuecomment-487762050

Raised this PR to make sure it's easier to find docs about package linking with this library