### PR TITLE
Fix development version in production bundle (Parcel)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var hasWindow = typeof window !== 'undefined';
 
-if (!module.hot || process.env.NODE_ENV === 'production' || !hasWindow) {
+if (process.env.NODE_ENV === 'production' || !module.hot || !hasWindow) {
   module.exports = require('./dist/react-hot-loader.production.min.js');
 } else {
   var evalAllowed = false;


### PR DESCRIPTION
> When I use parcel build to generate a production bundle for my project that uses react-hot-loader, the bundle ends up containing react-hot-loader.development.js. However I don't want the actual hot reloading code in my production bundle, and react-hot-loader is supposed to omit this when built for production.

https://github.com/parcel-bundler/parcel/issues/1593

![Screenshot from 2019-05-10 00-35-25](https://user-images.githubusercontent.com/29141708/57488362-8b1e9980-72bb-11e9-8cb4-e17820a5c910.png)

This PR fixes the issue just by changing the order of production checks