### PR TITLE
fix: No HMR missing error in SSR

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
 
 if (process.env.NODE_ENV === 'production') {
   module.exports = require('./dist/react-hot-loader.production.min.js');
-} else if (!module.hot) {
-  console.error('React-Hot-Loader: Hot Module Replacement is not enabled');
-  module.exports = require('./dist/react-hot-loader.production.min.js');
 } else if (typeof window === 'undefined') {
   // this is just server environment
+  module.exports = require('./dist/react-hot-loader.production.min.js');
+} else if (!module.hot) {
+  console.error('React-Hot-Loader: Hot Module Replacement is not enabled');
   module.exports = require('./dist/react-hot-loader.production.min.js');
 } else {
   var evalAllowed = false;


### PR DESCRIPTION
The second condition is triggered in a server environment resulting in the error message 
`React-Hot-Loader: Hot Module Replacement is not enabled`
Invert the two condition fixes this behavior