### PR TITLE
feat: transparent class wrapping

### DIFF
--- a/src/reactHotLoader.js
+++ b/src/reactHotLoader.js
@@ -117,53 +117,61 @@ const reactHotLoader = {
       configuration.showReactDomPatchNotification = false;
       // console.warn('react-🔥-loader activated.');
     }
-    /* eslint-enable */
-    if (!React.createElement.isPatchedByReactHotLoader) {
-      const originalCreateElement = React.createElement;
-      // Trick React into rendering a proxy so that
-      // its state is preserved when the class changes.
-      // This will update the proxy if it's for a known type.
-      React.createElement = (type, ...args) => originalCreateElement(resolveType(type), ...args);
-      React.createElement.isPatchedByReactHotLoader = true;
+    if (ReactDOM && ReactDOM.setHotTypeResolver) {
+      console.log('Types 2');
+      configuration.intergratedResolver = true;
+      ReactDOM.setHotTypeResolver(resolveType);
     }
 
-    if (!React.cloneElement.isPatchedByReactHotLoader) {
-      const originalCloneElement = React.cloneElement;
+    if (!configuration.intergratedResolver) {
+      /* eslint-enable */
+      if (!React.createElement.isPatchedByReactHotLoader) {
+        const originalCreateElement = React.createElement;
+        // Trick React into rendering a proxy so that
+        // its state is preserved when the class changes.
+        // This will update the proxy if it's for a known type.
+        React.createElement = (type, ...args) => originalCreateElement(resolveType(type), ...args);
+        React.createElement.isPatchedByReactHotLoader = true;
+      }
 
-      React.cloneElement = (element, ...args) => {
-        const newType = element.type && resolveType(element.type);
-        if (newType && newType !== element.type) {
-          return originalCloneElement(
-            {
-              ...element,
-              type: newType,
-            },
-            ...args,
-          );
-        }
-        return originalCloneElement(element, ...args);
-      };
+      if (!React.cloneElement.isPatchedByReactHotLoader) {
+        const originalCloneElement = React.cloneElement;
 
-      React.cloneElement.isPatchedByReactHotLoader = true;
-    }
+        React.cloneElement = (element, ...args) => {
+          const newType = element.type && resolveType(element.type);
+          if (newType && newType !== element.type) {
+            return originalCloneElement(
+              {
+                ...element,
+                type: newType,
+              },
+              ...args,
+            );
+          }
+          return originalCloneElement(element, ...args);
+        };
 
-    if (!React.createFactory.isPatchedByReactHotLoader) {
-      // Patch React.createFactory to use patched createElement
-      // because the original implementation uses the internal,
-      // unpatched ReactElement.createElement
-      React.createFactory = type => {
-        const factory = React.createElement.bind(null, type);
-        factory.type = type;
-        return factory;
-      };
-      React.createFactory.isPatchedByReactHotLoader = true;
-    }
+        React.cloneElement.isPatchedByReactHotLoader = true;
+      }
 
-    if (!React.Children.only.isPatchedByReactHotLoader) {
-      const originalChildrenOnly = React.Children.only;
-      // Use the same trick as React.createElement
-      React.Children.only = children => originalChildrenOnly({ ...children, type: resolveType(children.type) });
-      React.Children.only.isPatchedByReactHotLoader = true;
+      if (!React.createFactory.isPatchedByReactHotLoader) {
+        // Patch React.createFactory to use patched createElement
+        // because the original implementation uses the internal,
+        // unpatched ReactElement.createElement
+        React.createFactory = type => {
+          const factory = React.createElement.bind(null, type);
+          factory.type = type;
+          return factory;
+        };
+        React.createFactory.isPatchedByReactHotLoader = true;
+      }
+
+      if (!React.Children.only.isPatchedByReactHotLoader) {
+        const originalChildrenOnly = React.Children.only;
+        // Use the same trick as React.createElement
+        React.Children.only = children => originalChildrenOnly({ ...children, type: resolveType(children.type) });
+        React.Children.only.isPatchedByReactHotLoader = true;
+      }
     }
 
     if (React.useEffect && !React.useState.isPatchedByReactHotLoader) {

--- a/src/reactHotLoader.js
+++ b/src/reactHotLoader.js
@@ -115,12 +115,11 @@ const reactHotLoader = {
 
       reactHotLoader.IS_REACT_MERGE_ENABLED = true;
       configuration.showReactDomPatchNotification = false;
-      // console.warn('react-🔥-loader activated.');
-    }
-    if (ReactDOM && ReactDOM.setHotTypeResolver) {
-      console.log('Types 2');
-      configuration.intergratedResolver = true;
-      ReactDOM.setHotTypeResolver(resolveType);
+
+      if (ReactDOM.setHotTypeResolver) {
+        configuration.intergratedResolver = true;
+        ReactDOM.setHotTypeResolver(resolveType);
+      }
     }
 
     if (!configuration.intergratedResolver) {

--- a/src/reconciler/componentComparator.js
+++ b/src/reconciler/componentComparator.js
@@ -96,6 +96,7 @@ export const hotComponentCompare = (oldType, preNewType, setNewType, baseType) =
   let result = oldType === newType;
 
   if (
+    result ||
     !isReloadableComponent(oldType) ||
     !isReloadableComponent(newType) ||
     isColdType(oldType) ||

--- a/src/reconciler/componentComparator.js
+++ b/src/reconciler/componentComparator.js
@@ -5,6 +5,7 @@ import { areSwappable } from './utils';
 import { PROXY_KEY, UNWRAP_PROXY } from '../proxy';
 import { resolveType } from './resolver';
 import logger from '../logger';
+import configuration from '../configuration';
 
 const getInnerComponentType = component => {
   const unwrapper = component[UNWRAP_PROXY];
@@ -89,8 +90,9 @@ const compareComponents = (oldType, newType, setNewType, baseType) => {
 const knownPairs = new WeakMap();
 const emptyMap = new WeakMap();
 
-export const hotComponentCompare = (oldType, newType, setNewType, baseType) => {
+export const hotComponentCompare = (oldType, preNewType, setNewType, baseType) => {
   const hotActive = hotComparisonOpen();
+  const newType = configuration.intergratedResolver ? resolveType(preNewType) : preNewType;
   let result = oldType === newType;
 
   if (

--- a/src/webpack/patch.js
+++ b/src/webpack/patch.js
@@ -34,6 +34,16 @@ const additional = {
     'if (current!== null&&current.type===element.type)',
     'if (current!== null&&hotCompareElements(current.type,element.type,hotUpdateChild(current)))',
   ],
+
+  '16.8-type': [
+    'function createFiberFromTypeAndProps(type, // React$ElementType\nkey, pendingProps, owner, mode, expirationTime) {',
+    'function createFiberFromTypeAndProps(type, // React$ElementType\nkey, pendingProps, owner, mode, expirationTime) {type = hotResolveType(type);',
+  ],
+
+  '16.8-type-compact': [
+    'function createFiberFromTypeAndProps(type,// React$ElementType\nkey,pendingProps,owner,mode,expirationTime){',
+    'function createFiberFromTypeAndProps(type,// React$ElementType\nkey,pendingProps,owner,mode,expirationTime){type = hotResolveType(type);',
+  ]
 };
 
 const ReactHotLoaderInjection = `
@@ -44,6 +54,9 @@ var hotUpdateChild = function (child) {
       child.alternate.type = newType;
     }
   }
+};
+var hotResolveType = function (type) {
+  return type;
 };
 var hotCompareElements = function (oldType, newType) {
   return oldType === newType
@@ -79,6 +92,9 @@ var ReactDOM = {
   setHotElementComparator: function (newComparator) {
     hotCompareElements = newComparator
   },
+  setHotTypeResolver: function (newResolver) {
+    hotResolveType = newResolver;
+  },
 `;
 
 const defaultEnd = ['var ReactDOM = {', ReactHotLoaderInjection];
@@ -92,7 +108,7 @@ const injectionEnd = {
   '16.4-compact': defaultEndCompact,
 };
 
-const sign = '/* 🔥 this is hot-loader/react-dom 🔥 */';
+const sign = '/* 🔥 this is hot-loader/react-dom 4.8+ 🔥 */';
 
 function additionalTransform(source) {
   for (const key in additional) {


### PR DESCRIPTION
WIP
- moves class wrapper to a fiber level removing a parasite side effect from a user level.

This is a major milestone for __v5__ and removes one of the biggest RHL's sideeffect type comparison - #304

### State before
`hot-loader/react-dom` introduces controller type comparison. We injected a few things to `react-dom`
- `hotCleanup`, to cleanup hooks rendering
- `hotRenderWithHooks`, to be able to render hooks in `hotReplacementRender`
- `setHotElementComparator`, to control type comparison, injected into `reconcileSingleElement`

### New
This PR adds one more injection
- `setHotTypeResolver` injected into `createFiberFromTypeAndProps`

### How it works
- no more user-space proxying
- Elements are passed to as-is, so `<Type/>.type==Type` both for `FC`(worked before), and now for `Classes`
- On fiber creation we are replacing the original `type` but a `proxy`
- `hotElementComparator`, which compares `fiber` node with `element` now compares `proxy` with the original type, and have to `wrap` element to perform comparison.

This is a replacement for #1138 

### Left to do
- changing hook order still throws an error
- classes are still could not be fully updated due to unrepeatable constructors.

I recon the second issue could be if not skipped, then deprecated due to the hooks.