### PR TITLE
Fix React.memo

### DIFF
--- a/src/fresh/babel.js
+++ b/src/fresh/babel.js
@@ -202,7 +202,7 @@ export default function(babel) {
       key: fnHookCalls.map(call => call.name + '{' + call.key + '}').join('\n'),
       customHooks: fnHookCalls
         .filter(call => !isBuiltinHook(call.name))
-        .map(call => t.clone(call.callee)),
+        .map(call => t.cloneDeep(call.callee)),
     };
   }
 

--- a/src/reconciler/proxies.js
+++ b/src/reconciler/proxies.js
@@ -37,10 +37,10 @@ export const updateFunctionProxyById = (id, type, updater) => {
   idsByType.set(type, id);
   const proxy = proxiesByID[id];
   if (!proxy) {
-    idsByType.set(type, id);
     proxiesByID[id] = type;
   }
   updater(proxiesByID[id], type);
+  // proxiesByID[id] = type; // keep the first ref
 
   return proxiesByID[id];
 };


### PR DESCRIPTION
That was supposed to be a small fix, but:
- `memo`-ed components update is broken since 4.10. 4.9 was the last working version. Thanks to @natew for reporting the issue.
- during the fix, more stuff was confirmed to be broken.
-  more automated tests, more manual tests
- should 🤞be ok now.