### PR TITLE
Replace lodash/merge with a very simple deep merge

### DIFF
--- a/src/reconciler/proxies.js
+++ b/src/reconciler/proxies.js
@@ -3,8 +3,7 @@ import { resetClassProxies } from '../proxy/createClassProxy';
 import { isCompositeComponent, isReactClass } from '../internal/reactUtils';
 import configuration from '../configuration';
 import { incrementHotGeneration } from '../global/generation';
-
-const merge = require('lodash/merge');
+import { merge } from './utils';
 
 let signatures;
 let proxiesByID;

--- a/src/reconciler/utils.js
+++ b/src/reconciler/utils.js
@@ -74,3 +74,25 @@ export const areSwappable = (a, b) => {
   }
   return false;
 };
+
+export function merge(...sources) {
+  let acc = {};
+  for (const source of sources) {
+    if (source instanceof Array) {
+      if (!(acc instanceof Array)) {
+        acc = [];
+      }
+      acc = [...acc, ...source];
+    } else if (source instanceof Object) {
+      for (const entry of Object.entries(source)) {
+        const key = entry[0];
+        let value = entry[1];
+        if (value instanceof Object && key in acc) {
+          value = merge(acc[key], value);
+        }
+        acc = { ...acc, [key]: value };
+      }
+    }
+  }
+  return acc;
+}


### PR DESCRIPTION
This is by no means an equivalent function, but I'm just wondering - isn't this enough?

In fact, maybe the `updateProxyById` code could be restructured to avoid the need to deep merge in the first place? I'm not familiar with the code enough to know if this merge replacement is sufficient to merge `renderOptions` and `componentOptions`.

Note, even arrays are merged differently using this code:

```js
var object = {
  'a': [{ 'b': 2 }, { 'd': 4 }]
};
 
var other = {
  'a': [{ 'c': 3 }, { 'e': 5 }]
};
 
_.merge(object, other);
// => positional merge { 'a': [{ 'b': 2, 'c': 3 }, { 'd': 4, 'e': 5 }] }

merge(object, other);
// => concat the arrays { 'a': [{ 'b': 2, 'd': 4, 'c': 3, 'e': 5 }] }
```

Fix #1269