### PR TITLE
4.12.7

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ index.js
 patch.js
 root.js
 test/hot/react-dom
+coverage

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ There is only one condition for it - a non zero dependencies list.
 🔥 useEffect(effect, ["hot"]); // the simplest way to make hook reloadable
 ```
 
+**Plus**
+
+* any hook would be reloaded on a function body change. Enabled by default, controlled by `reloadHooksOnBodyChange` option.
+* you may configure RHL to reload any hook by setting `reloadLifeCycleHooks` option to true.
+
 **To disable hooks reloading** - set configuration option:
 
 ```js

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -11,8 +11,14 @@ const configuration = {
   // Allows SFC to be used, enables "intermediate" components used by Relay, should be disabled for Preact
   allowSFC: true,
 
-  // Allow hot reload of effect hooks
+  // Allow reload of effect hooks with non zero dependency list
   reloadHooks: true,
+
+  // Allow reload of mount effect hooks - zero deps
+  reloadLifeCycleHooks: false,
+
+  // Enables hook reload on hook body change
+  reloadHooksOnBodyChange: true,
 
   // Disable "hot-replacement-render"
   disableHotRenderer: false,

--- a/src/reactHotLoader.js
+++ b/src/reactHotLoader.js
@@ -29,8 +29,24 @@ const forceSimpleSFC = { proxy: { pureSFC: true } };
 
 const hookWrapper = hook => {
   const wrappedHook = function(cb, deps) {
-    if (configuration.reloadHooks) {
-      return hook(cb, deps && deps.length > 0 ? [...deps, getHotGeneration()] : deps);
+    if (configuration.reloadHooks && deps) {
+      const inputs = [...deps];
+
+      // reload hooks which have changed string representation
+      if (configuration.reloadHooksOnBodyChange) {
+        inputs.push(String(cb));
+      }
+
+      if (
+        // reload hooks with dependencies
+        deps.length > 0 ||
+        // reload all hooks of option is set
+        (configuration.reloadLifeCycleHooks && deps.length === 0)
+      ) {
+        inputs.push(getHotGeneration());
+      }
+
+      return hook(cb, inputs);
     }
     return hook(cb, deps);
   };

--- a/src/reconciler/resolver.js
+++ b/src/reconciler/resolver.js
@@ -12,17 +12,23 @@ import configuration, { internalConfiguration } from '../configuration';
 const shouldNotPatchComponent = type => isTypeBlacklisted(type);
 
 export function resolveType(type, options = {}) {
-  const element = { type };
-  if (isLazyType(element) || isMemoType(element) || isForwardType(element) || isContextType(element)) {
-    return getProxyByType(type) || type;
-  }
-
+  // fast return
   if (!isCompositeComponent(type) || isProxyType(type)) {
     return type;
   }
 
+  const element = { type };
+
+  // fast meta
+  if (typeof element === 'object') {
+    if (isLazyType(element) || isMemoType(element) || isForwardType(element) || isContextType(element)) {
+      return getProxyByType(type) || type;
+    }
+  }
+
   const existingProxy = getProxyByType(type);
 
+  // cold API
   if (shouldNotPatchComponent(type)) {
     return existingProxy ? existingProxy.getCurrent() : type;
   }


### PR DESCRIPTION
- reload hooks when hook body changes, that would make "mount" hooks more predictable.
- false negative comparisons with react-hot-dom enabled, #1299