### PR TITLE
fix: script error on IE11 due to lack of Object.entries

### DIFF
--- a/src/reconciler/utils.js
+++ b/src/reconciler/utils.js
@@ -84,9 +84,8 @@ export function merge(...sources) {
       }
       acc = [...acc, ...source];
     } else if (source instanceof Object) {
-      for (const entry of Object.entries(source)) {
-        const key = entry[0];
-        let value = entry[1];
+      for (const key of Object.keys(source)) {
+        let value = source[key];
         if (value instanceof Object && key in acc) {
           value = merge(acc[key], value);
         }


### PR DESCRIPTION
Usage of `Object.entries` (by https://github.com/gaearon/react-hot-loader/pull/1288) cause script error on IE11 due to lack of support.

Use `Object.keys` instead, as `Object.keys` has been used multiple times within the codebase, and has better browser support. 