### PR TITLE
Update Context Provider, fixes #1207

### DIFF
--- a/examples/styled-components/src/Counter.js
+++ b/examples/styled-components/src/Counter.js
@@ -7,7 +7,8 @@ const ComponentA = () => {
   const [state] = useState('A');
   return (
     <div>
-      {state}-{value}
+      {state}-{value}-
+      <TimerContext.Consumer>{v => v}</TimerContext.Consumer>
     </div>
   );
 };
@@ -17,7 +18,8 @@ const ComponentB = () => {
   const value = useContext(TimerContext);
   return (
     <div>
-      {state}-{value}
+      {state}-{value}-
+      <TimerContext.Consumer>{v => v}</TimerContext.Consumer>
     </div>
   );
 };

--- a/examples/styled-components/src/Spring.js
+++ b/examples/styled-components/src/Spring.js
@@ -1,5 +1,18 @@
 import { animated, useSpring } from 'react-spring';
 import React, { useCallback, useState } from 'react';
+import Counter from './Counter';
+
+const context = React.createContext('test1');
+
+const Test = () => {
+  const v = React.useContext(context);
+
+  return (
+    <div>
+      --{v}-- ##<Counter />
+    </div>
+  );
+};
 
 export function SpringTest() {
   const [thingDone, toggleThingDone] = useState(false);
@@ -7,8 +20,17 @@ export function SpringTest() {
 
   const fader = useSpring({ opacity: thingDone ? 1 : 0 });
 
+  const v = React.useContext(context);
+
   return (
     <React.Fragment>
+      {v}
+      <context.Provider value={24}>
+        <Test />
+      </context.Provider>
+      <context.Provider value="test2">
+        <Test />
+      </context.Provider>
       <animated.h1 style={fader}>You did the thing!</animated.h1>
       <button type="button" onClick={doTheThing}>
         {thingDone ? 'Undo The Thing' : 'Do The Thing'}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -24,6 +24,8 @@ const configuration = {
   disableHotRenderer: false,
 
   // @private
+  integratedComparator: false,
+  // @private
   integratedResolver: false,
 
   // Disable "hot-replacement-render" when injection into react-dom is made

--- a/src/errorReporter.js
+++ b/src/errorReporter.js
@@ -72,7 +72,7 @@ const mapError = ({ error, errorInfo, component }) => (
   <React.Fragment>
     <p style={{ color: 'red' }}>
       {errorHeader(component, errorInfo && errorInfo.componentStack)}{' '}
-      {error.toString ? error.toString() : error.message || 'undefined error'}
+      {error.toString ? error.toString() : (error && error.message) || 'undefined error'}
     </p>
     {errorInfo && errorInfo.componentStack ? (
       <div>

--- a/src/reactHotLoader.js
+++ b/src/reactHotLoader.js
@@ -143,6 +143,7 @@ const reactHotLoader = {
 
       reactHotLoader.IS_REACT_MERGE_ENABLED = true;
       configuration.showReactDomPatchNotification = false;
+      configuration.integratedComparator = true;
 
       if (ReactDOM.setHotTypeResolver) {
         configuration.integratedResolver = true;
@@ -151,61 +152,59 @@ const reactHotLoader = {
       }
     }
 
-    if (!configuration.integratedResolver) {
-      // PATCH REACT METHODS
+    // PATCH REACT METHODS
 
-      /* eslint-enable */
-      if (!React.createElement.isPatchedByReactHotLoader) {
-        const originalCreateElement = React.createElement;
-        // Trick React into rendering a proxy so that
-        // its state is preserved when the class changes.
-        // This will update the proxy if it's for a known type.
-        React.createElement = (type, ...args) => originalCreateElement(typeResolver(type), ...args);
-        React.createElement.isPatchedByReactHotLoader = true;
-      }
+    /* eslint-enable */
+    if (!React.createElement.isPatchedByReactHotLoader) {
+      const originalCreateElement = React.createElement;
+      // Trick React into rendering a proxy so that
+      // its state is preserved when the class changes.
+      // This will update the proxy if it's for a known type.
+      React.createElement = (type, ...args) => originalCreateElement(typeResolver(type), ...args);
+      React.createElement.isPatchedByReactHotLoader = true;
+    }
 
-      if (!React.cloneElement.isPatchedByReactHotLoader) {
-        const originalCloneElement = React.cloneElement;
+    if (!React.cloneElement.isPatchedByReactHotLoader) {
+      const originalCloneElement = React.cloneElement;
 
-        React.cloneElement = (element, ...args) => {
-          const newType = element.type && typeResolver(element.type);
-          if (newType && newType !== element.type) {
-            return originalCloneElement(
-              {
-                ...element,
-                type: newType,
-              },
-              ...args,
-            );
-          }
-          return originalCloneElement(element, ...args);
-        };
+      React.cloneElement = (element, ...args) => {
+        const newType = element.type && typeResolver(element.type);
+        if (newType && newType !== element.type) {
+          return originalCloneElement(
+            {
+              ...element,
+              type: newType,
+            },
+            ...args,
+          );
+        }
+        return originalCloneElement(element, ...args);
+      };
 
-        React.cloneElement.isPatchedByReactHotLoader = true;
-      }
+      React.cloneElement.isPatchedByReactHotLoader = true;
+    }
 
-      if (!React.createFactory.isPatchedByReactHotLoader) {
-        // Patch React.createFactory to use patched createElement
-        // because the original implementation uses the internal,
-        // unpatched ReactElement.createElement
-        React.createFactory = type => {
-          const factory = React.createElement.bind(null, type);
-          factory.type = type;
-          return factory;
-        };
-        React.createFactory.isPatchedByReactHotLoader = true;
-      }
+    if (!React.createFactory.isPatchedByReactHotLoader) {
+      // Patch React.createFactory to use patched createElement
+      // because the original implementation uses the internal,
+      // unpatched ReactElement.createElement
+      React.createFactory = type => {
+        const factory = React.createElement.bind(null, type);
+        factory.type = type;
+        return factory;
+      };
+      React.createFactory.isPatchedByReactHotLoader = true;
+    }
 
-      if (!React.Children.only.isPatchedByReactHotLoader) {
-        const originalChildrenOnly = React.Children.only;
-        // Use the same trick as React.createElement
-        React.Children.only = children =>
-          originalChildrenOnly({
-            ...children,
-            type: typeResolver(children.type),
-          });
-        React.Children.only.isPatchedByReactHotLoader = true;
-      }
+    if (!React.Children.only.isPatchedByReactHotLoader) {
+      const originalChildrenOnly = React.Children.only;
+      // Use the same trick as React.createElement
+      React.Children.only = children =>
+        originalChildrenOnly({
+          ...children,
+          type: typeResolver(children.type),
+        });
+      React.Children.only.isPatchedByReactHotLoader = true;
     }
 
     // PATCH REACT HOOKS

--- a/src/reconciler/componentComparator.js
+++ b/src/reconciler/componentComparator.js
@@ -14,6 +14,7 @@ import { PROXY_KEY, UNWRAP_PROXY } from '../proxy';
 import { resolveType } from './resolver';
 import logger from '../logger';
 import configuration from '../configuration';
+import { updateLazy } from './fiberUpdater';
 
 const getInnerComponentType = component => {
   const unwrapper = component[UNWRAP_PROXY];
@@ -153,6 +154,7 @@ const compareComponents = (oldType, newType, setNewType, baseType) => {
   }
 
   if (isLazyType({ type: oldType })) {
+    updateLazy(oldType, newType);
     // no need to update
     // setNewType(newType);
     return defaultResult;

--- a/src/reconciler/componentComparator.js
+++ b/src/reconciler/componentComparator.js
@@ -153,10 +153,14 @@ const compareComponents = (oldType, newType, setNewType, baseType) => {
   }
 
   if (isLazyType({ type: oldType })) {
+    // no need to update
+    // setNewType(newType);
     return defaultResult;
   }
 
   if (isContextType({ type: oldType })) {
+    // update provider
+    setNewType(newType);
     return defaultResult;
   }
 

--- a/src/reconciler/fiberUpdater.js
+++ b/src/reconciler/fiberUpdater.js
@@ -6,13 +6,9 @@ import { resolveType } from './resolver';
 
 const lazyConstructor = '_ctor';
 
-export const updateLazy = (target, type) => {
-  const ctor = type[lazyConstructor];
-  if (target[lazyConstructor] !== type[lazyConstructor]) {
-    // just execute `import` and RHL.register will do the job
-    ctor();
-  }
+const patchLazyContructor = target => {
   if (!target[lazyConstructor].isPatchedByReactHotLoader) {
+    const ctor = target[lazyConstructor];
     target[lazyConstructor] = () =>
       ctor().then(m => {
         const C = resolveType(m.default);
@@ -37,6 +33,16 @@ export const updateLazy = (target, type) => {
       });
     target[lazyConstructor].isPatchedByReactHotLoader = true;
   }
+};
+
+export const updateLazy = (target, type) => {
+  const ctor = type[lazyConstructor];
+  if (target[lazyConstructor] !== type[lazyConstructor]) {
+    // just execute `import` and RHL.register will do the job
+    ctor();
+  }
+  patchLazyContructor(target);
+  patchLazyContructor(type);
 };
 
 export const updateMemo = (target, { type }) => {

--- a/src/reconciler/resolver.js
+++ b/src/reconciler/resolver.js
@@ -12,10 +12,16 @@ import configuration, { internalConfiguration } from '../configuration';
 const shouldNotPatchComponent = type => isTypeBlacklisted(type);
 
 export function resolveUtility(type) {
-  const element = { type };
+  // all "utility" types are resolved to their __initial__ shapes
+  // that enables to never change reference to them, and gives the ability to maintain React Tree on HMR
 
-  // fast meta
-  if (typeof element === 'object') {
+  // all operations could be skipped with react-hot-dom enabled
+
+  if (typeof type === 'object') {
+    if (configuration.integratedComparator) {
+      return type;
+    }
+    const element = { type };
     if (isLazyType(element) || isMemoType(element) || isForwardType(element) || isContextType(element)) {
       return getProxyByType(type) || type;
     }
@@ -60,8 +66,7 @@ export function resolveNotComponent(type) {
   return undefined;
 }
 
-export const resolveSimpleType = type =>
-  resolveProxy(type) || resolveUtility(type) || resolveNotComponent(type) || type;
+export const resolveSimpleType = type => resolveProxy(type) || resolveUtility(type) || type;
 
 export const resolveType = (type, options = {}) =>
   resolveProxy(type) || resolveUtility(type) || resolveNotComponent(type) || resolveComponent(type, options) || type;

--- a/src/reconciler/resolver.js
+++ b/src/reconciler/resolver.js
@@ -11,12 +11,7 @@ import configuration, { internalConfiguration } from '../configuration';
 
 const shouldNotPatchComponent = type => isTypeBlacklisted(type);
 
-export function resolveType(type, options = {}) {
-  // fast return
-  if (!isCompositeComponent(type) || isProxyType(type)) {
-    return type;
-  }
-
+export function resolveUtility(type) {
   const element = { type };
 
   // fast meta
@@ -26,6 +21,10 @@ export function resolveType(type, options = {}) {
     }
   }
 
+  return undefined;
+}
+
+export function resolveComponent(type, options = {}) {
   const existingProxy = getProxyByType(type);
 
   // cold API
@@ -35,10 +34,34 @@ export function resolveType(type, options = {}) {
 
   if (!existingProxy && configuration.onComponentCreate) {
     configuration.onComponentCreate(type, getComponentDisplayName(type));
-    if (shouldNotPatchComponent(type)) return type;
+    if (shouldNotPatchComponent(type)) {
+      return type;
+    }
   }
 
   const proxy = internalConfiguration.disableProxyCreation ? existingProxy : createProxyForType(type, options);
 
-  return proxy ? proxy.get() : type;
+  return proxy ? proxy.get() : undefined;
 }
+
+export function resolveProxy(type) {
+  if (isProxyType(type)) {
+    return type;
+  }
+
+  return undefined;
+}
+
+export function resolveNotComponent(type) {
+  if (!isCompositeComponent(type)) {
+    return type;
+  }
+
+  return undefined;
+}
+
+export const resolveSimpleType = type =>
+  resolveProxy(type) || resolveUtility(type) || resolveNotComponent(type) || type;
+
+export const resolveType = (type, options = {}) =>
+  resolveProxy(type) || resolveUtility(type) || resolveNotComponent(type) || resolveComponent(type, options) || type;

--- a/test/hot/react-dom.integration.spec.js
+++ b/test/hot/react-dom.integration.spec.js
@@ -111,7 +111,12 @@ describe(`🔥-dom`, () => {
         const RenderContext = () => {
           const v = React.useContext(context);
 
-          return <span>contextValue={v}</span>;
+          return (
+            <span>
+              contextValue={v}
+              <context.Consumer>{v => `~${v}~`}</context.Consumer>
+            </span>
+          );
         };
 
         const MountCheck = () => {
@@ -143,6 +148,7 @@ describe(`🔥-dom`, () => {
 
       expect(el.innerHTML).toMatch(/1-test-1/);
       expect(el.innerHTML).toMatch(/~1-test-1~/);
+      expect(el.innerHTML).toMatch(/~~1-test-1~~/);
 
       incrementHotGeneration();
       {
@@ -154,6 +160,7 @@ describe(`🔥-dom`, () => {
 
       expect(el.innerHTML).toMatch(/2-hot-2/);
       expect(el.innerHTML).toMatch(/~2-hot-2~/);
+      expect(el.innerHTML).toMatch(/~~2-hot-2~~/);
 
       expect(mount).toHaveBeenCalledTimes(1);
       expect(unmount).toHaveBeenCalledTimes(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,11 +4594,6 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
-lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 lodash@^4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"


### PR DESCRIPTION
Bug: 4.12+ versions, with `hot-loader/react-dom` enables are not properly handling React.Context if `integratedResolver` is enabled (and it is)

Details: Context values are reset to the defaults.

Reason: "new" context is used to read data from, "old" to provide data. So there is no "new" data.

Fix: update fiber.

Probably better fix: split `resolver` into two parts - to still wrap `lazy`, `context` and other things with proxies, but not wrapping `classes` and `FC`s is it's possible not to wrap.