### PR TITLE
Update troubleshooting doc with new tip

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -113,6 +113,17 @@ Generally, the best way to fix this class of errors is to compare your setup to 
 
 WebpackDevServer CLI mode [behaves slightly differently](https://github.com/webpack/webpack-dev-server/issues/106) from its Node API. When in doubt, I suggest you use Node API like [React Hot Boilerplate does](https://github.com/gaearon/react-hot-boilerplate/blob/master/server.js).
 
+#### Check your NODE_ENV value
+
+If you are seeing an error like this:
+
+```
+[HMR] The following modules couldn't be hot updated: (Full reload needed)
+This is usually because the modules which have changed (and their parents) do not know how to hot reload themselves.
+```
+
+You may have `NODE_ENV` set to either `production` or `test`. Setting `NODE_ENV` to either of these will cause `react-hot-loader` to compile in production mode. Try setting `NODE_ENV` to something like `development`.
+
 #### Uncaught RangeError: Maximum call stack size exceeded
 
 When using WebpackDevServer CLI flag `--hot`, the plugin `new HotModuleReplacementPlugin()` should not be used and vice versa, they are mutually exclusive but the desired effect will work with any of them.


### PR DESCRIPTION
Setting `NODE_ENV` to `production` seems obvious that it would turn hot-reloading off, however setting `NODE_ENV` to `test` seems much less obvious and worth a call out.

This is an issue that I ran into with my project setup that was hard to track down. First I wasn't sure why the components didn't know how to hot reload since I followed the examples and had wrapped them properly with `export default hot(Component)`. There wasn't any messaging to tell me that `react-hot-loader` was running in production mode, so it was hard to figure out. After looking through all the documentation (including this file) and exhausting everything I found there I looked into the source code and found that when `NODE_ENV === 'test'`, react-hot-loader runs in production mode. I would have had a much easier time figuring it out had there been a tip here, so I thought I should add it for anyone that runs into this in the future.

