### PR TITLE
4.12.15

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,18 +13,28 @@ if (process.env.NODE_ENV === 'production') {
   module.exports.hot.shouldWrapWithAppContainer = true;
 } else {
   var evalAllowed = false;
+  var evalError = null;
   try {
     eval('evalAllowed = true');
   } catch (e) {
     // eval not allowed due to CSP
+    evalError = e && e.message ? e.message : 'unknown reason';
   }
 
+  // TODO: dont use eval to update methods. see #1273
   // RHL needs setPrototypeOf to operate Component inheritance, and eval to patch methods
   var jsFeaturesPresent = !!Object.setPrototypeOf;
 
   if (!jsFeaturesPresent || !evalAllowed) {
     // we are not in prod mode, but RHL could not be activated
-    console.warn('React-Hot-Loader is not supported in this environment.');
+    console.warn(
+      'React-Hot-Loader is not supported in this environment:',
+      [
+        !jsFeaturesPresent && "some JS features are missing",
+        !evalAllowed && "`eval` is not allowed(" + evalError + ")"
+      ].join(','),
+      '.'
+    );
     module.exports = require('./dist/react-hot-loader.production.min.js');
   } else {
     module.exports = window.reactHotLoaderGlobal = require('./dist/react-hot-loader.development.js');

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   ],
   "devDependencies": {
     "@hot-loader/react-dom": "^16.8.6",
-    "@types/react": "^16.9.1",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
@@ -103,6 +102,7 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@types/react": "^15.0.0 || ^16.0.0",
     "fast-levenshtein": "^2.0.6",
     "global": "^4.3.0",
     "hoist-non-react-statics": "^3.3.0",

--- a/src/hot.dev.js
+++ b/src/hot.dev.js
@@ -66,7 +66,7 @@ const makeHotExport = (sourceModule, moduleId) => {
                 // we know that some components were updated, but not tracking which ones
                 // even if their updates might be incorporated automatically (like lazy)
                 // we dont know which one should be tracked, and which updates are important
-                console.warn(
+                logger.warn(
                   'React-Hot-Loader: some components were updated out-of-bound. Updating your app to reconcile the changes.',
                 );
                 deepUpdate();

--- a/src/internal/getReactStack.js
+++ b/src/internal/getReactStack.js
@@ -42,7 +42,10 @@ const markUpdate = ({ fiber }) => {
   if (fiber.alternate) {
     fiber.alternate.expirationTime = 1;
     fiber.alternate.type = fiber.type;
-    fiber.alternate.elementType = fiber.elementType;
+    // elementType might not exists in older react versions
+    if ('elementType' in fiber.alternate) {
+      fiber.alternate.elementType = fiber.elementType;
+    }
   }
 
   if (fiber.memoizedProps && typeof fiber.memoizedProps === 'object') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.7.tgz#c6f1e0d0109ff358b132d98b7b4025c7a7b707c5"
   integrity sha512-a6WH0fXkgPNiGIuLjjdpf0n/GnmgWZ4vLuVIJJnDwhmRDPEaiRBcy5ofQPh+EJFua0S1QWmk1745+JqZQGnJ8Q==
 
-"@types/react@^16.9.1":
-  version "16.9.1"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.1.tgz#862c83b4c9d5cd116e42fd9a4f3694843cd2c051"
-  integrity sha512-jGM2x8F7m7/r+81N/BOaUKVwbC5Cdw6ExlWEUpr77XPwVeNvAppnPEnMMLMfxRDYL8FPEX8MHjwtD2NQMJ0yyQ==
+"@types/react@^16.9.11":
+  version "16.9.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"
+  integrity sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
- fix: use logger.warn instead of console to report tail update, fixes #…  …
- fix: dont write to elementType if it is not defined, fixes #1357
- fix: more @types/react to dependencies, fixes #1359
- fix: explain why RHL could not be activated, fixes #1362