### PR TITLE
Fix styles for code blocks because of nested .highlight elements

### DIFF
--- a/public/css/playground.css
+++ b/public/css/playground.css
@@ -352,7 +352,7 @@ small code,li code,p code {
     text-align: right;
 }
 
-.highlight:after {
+div.highlight:after {
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
For some reason the highlighter output:

```html
<div class="highlight">
  <pre class="highlight">
    <!-- ... -->
  </pre>
</div>
```

which causes all styles with the selector `.highlight` to be applied on both. Most of them don't have a visible impact, except the one which adds a pseudo-element:

<img width="486" alt="Screen Shot 2020-02-17 at 19 01 38" src="https://user-images.githubusercontent.com/471278/74677156-efaa4580-51b7-11ea-8ef9-c93736ee3bb8.png">

This is now fixed by specifying the element.