### PR TITLE
Babel plugin: support BABEL_ENV "production"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ Here is a quick guide to doing code contributions to the library.
 
 4.  Make your changes and commit: `git add` and `git commit`
 
-5.  Make sure that the tests still pass: `yarn test:es2015 --watch` and `yarn test:modern --watch`
+5.  Make sure that the tests still pass: run `yarn build`, `yarn test:react-dom:prepare`, then `yarn test:es2015 --watch` and `yarn test:modern --watch`
+    a. Alternatively, run the ci scripts: [/scripts/ci.sh](/scripts/ci.sh)
 
 6.  Push your branch: `git push -u origin your-branch-name`
 

--- a/babel.js
+++ b/babel.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.BABEL_ENV === 'production') {
   module.exports = require('./dist/babel.production.min.js');
 } else {
   module.exports = require('./dist/babel.development.js');

--- a/examples/typescript-no-babel/README.md
+++ b/examples/typescript-no-babel/README.md
@@ -1,2 +1,3 @@
 # Attention!!!
-- Hook reloading is relaying on babel plugin! This example don't support hooks reload. If you want to have hook reloading, use typescript with babel.
+
+* Hook reloading is relaying on babel plugin! This example don't support hooks reload. If you want to have hook reloading, use typescript with babel.

--- a/src/errorReporter.js
+++ b/src/errorReporter.js
@@ -28,7 +28,7 @@ const overlayStyle = {
   padding: '16px',
   maxHeight: '50%',
   overflow: 'auto',
-  zIndex: 10000
+  zIndex: 10000,
 };
 
 const inlineErrorStyle = {


### PR DESCRIPTION
**Changes**
In babel plugin, supporting using `process.env.BABEL_ENV` in addition to `process.env.NODE_ENV` to mirror babel's configuration API for envName: https://babeljs.io/docs/en/options#envname

This allows apps to create built-like-production bundles with webpack and still switch on NODE_ENV within application code for application-level uses.

**Tests**
I updated CONTRIBUTING.md to include some test prerequisites. 
I wasn't able to test any of the examples in the repo via `yarn install file:../packages/react-hot-loader`.